### PR TITLE
fix: repair test suite so npm publish can ship

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Official Node.js SDK for Oil Price API - Real-time and historical oil & commodity prices",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,7 +7,7 @@
  * - X-Client-Version header
  * - Package.json (should match)
  */
-export const SDK_VERSION = "0.8.0";
+export const SDK_VERSION = "0.8.1";
 
 /**
  * SDK identifier used in User-Agent and X-Api-Client headers

--- a/tests/integration/user-agent-integration.test.ts
+++ b/tests/integration/user-agent-integration.test.ts
@@ -26,9 +26,16 @@ describe("User-Agent Integration Tests", () => {
     });
   });
 
-  it("should export SDK_VERSION constant", () => {
+  it("should export SDK_VERSION constant", async () => {
+    // Derive the expected version from package.json (single source of truth)
+    // rather than hard-coding a literal. A hard-coded version here previously
+    // broke the publish test gate whenever the package version was bumped.
+    const packageJson = await import("../../package.json", {
+      assert: { type: "json" },
+    });
     expect(SDK_VERSION).toBeDefined();
-    expect(SDK_VERSION).toBe("0.8.0");
+    expect(SDK_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(SDK_VERSION).toBe(packageJson.default.version);
   });
 
   it("should export SDK_NAME constant", () => {


### PR DESCRIPTION
## Root cause

The npm package `oilpriceapi` is stuck at **0.7.0** even though the repo is tagged `v0.8.0`. The publish workflow (`.github/workflows/publish.yml`) runs a pre-publish gate (`tsc --noEmit`, `npm test`, `npm run build`) before `npm publish`, and that gate **failed** on the `v0.8.0` release run.

The reason was a tag-ordering problem, not a live test defect:

- The `v0.8.0` release/tag points at commit `4018692` ("feat: v0.8.0").
- The test-mock fix `778aa02` ("Fix all test mocks for request() text() change, update version assertions") landed on `main` **after** the tag.
- The `release: published` workflow checks out the tagged commit (`4018692`), which still had the broken mocks, so the test gate failed and nothing published.

At current `main` HEAD the full gate is already green (279 passed, 1 skipped; tsc/build/lint clean), but `main` was never re-tagged, so npm never updated.

## What this changes

1. **Bump version 0.8.0 → 0.8.1** (`package.json`, `src/version.ts`) so a fresh release can run the now-green gate and actually ship.
2. **De-brittle `tests/integration/user-agent-integration.test.ts`.** It previously hard-coded `expect(SDK_VERSION).toBe("0.8.0")`. That literal is the same trap that would re-break the publish gate on the very next version bump (you'd have to edit `package.json`, `version.ts`, and the test literal in lockstep or the gate fails). The assertion now derives the expected version from `package.json` (single source of truth) and just validates the semver shape, so version bumps no longer require touching a test literal.

## Verification (full publish gate, run locally on this branch)

- `npx tsc --noEmit` → exit 0
- `npm test` → **279 passed, 1 skipped**, 0 failures
- `npm run build` → exit 0
- `npm run lint` → exit 0 (10 pre-existing `no-explicit-any` warnings, 0 errors)

No tests were deleted and no timeouts were bumped — the suite mocks the network as before; nothing here makes real network calls.

## Follow-up (human action)

Once this is merged, **cut a `v0.8.1` release/tag on `main`** to trigger the publish workflow. The gate will pass and `oilpriceapi@0.8.1` will publish to npm, unsticking it from 0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released SDK version 0.8.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->