### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,9 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Upgrade npm (OIDC trusted publishing needs npm >= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
@@ -33,7 +36,8 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Authentication via OIDC Trusted Publishing (configured on npmjs.com).
+      # No NODE_AUTH_TOKEN needed; OIDC also satisfies the package 2FA requirement
+      # and produces provenance automatically.
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Eliminates the NPM_TOKEN dependency that has blocked publishing (2FA-bypass token requirement). OIDC trusted publishing satisfies the package 2FA policy and auto-generates provenance. Requires a Trusted Publisher configured on npmjs.com for this repo + publish.yml.