### PR TITLE
chore: bump version to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Official Node.js SDK for Oil Price API - Real-time and historical oil & commodity prices",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,7 +7,7 @@
  * - X-Client-Version header
  * - Package.json (should match)
  */
-export const SDK_VERSION = "0.8.1";
+export const SDK_VERSION = "0.8.2";
 
 /**
  * SDK identifier used in User-Agent and X-Api-Client headers


### PR DESCRIPTION
Bumps package.json + version.ts to 0.8.2 so the release tag sits on the OIDC-enabled workflow commit. Release events run the workflow from the tag's commit, so v0.8.1 (pre-OIDC) kept running the old token workflow.