### PR TITLE
feat: raw-response, futures helpers, spreads + indicators resources, EI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The official Node.js/TypeScript SDK for [OilPriceAPI](https://www.oilpriceapi.co
 - ⛽ **NEW v0.4.0** - Diesel prices (state averages + station-level pricing)
 - 🔔 **NEW v0.5.0** - Price alerts with webhook notifications
 - 📊 **NEW v0.7.0** - Futures, storage, rig counts, analytics, drilling intelligence, webhooks, and energy intelligence
+- 🧰 **NEW** - Typed ICE Brent / Gasoil / WTI & gas/carbon futures helpers, `spreads`, `indicators`, and raw HTTP responses (`client.raw.*` with status + headers)
 
 ## Installation
 
@@ -267,9 +268,7 @@ console.log("Alert deleted successfully");
 const result = await client.alerts.testWebhook("https://your-app.com/webhook");
 
 if (result.success) {
-  console.log(
-    `Webhook OK (${result.status_code}) - ${result.response_time_ms}ms`,
-  );
+  console.log(`Webhook OK (${result.status_code}) - ${result.response_time_ms}ms`);
 } else {
   console.error(`Webhook failed: ${result.error}`);
 }
@@ -341,6 +340,138 @@ curve.curve.forEach((point) => {
 });
 ```
 
+#### Typed contract-family helpers (ICE Brent, Gasoil, WTI, gas & carbon)
+
+The generic `futures.*` methods take raw contract codes. For the most-requested
+families you can use ergonomic, typed helpers that map to the
+`/v1/futures/{family}/...` endpoints — no need to remember URL slugs. Each
+family supports `latest`, `historical`, `ohlc`, `intraday`, `spreads`, `curve`,
+and `spreadHistory`.
+
+```typescript
+import { OilPriceAPI, FUTURES_CONTRACTS } from "oilpriceapi";
+
+const client = new OilPriceAPI({ apiKey: "your_key" });
+
+// ICE Brent
+const brent = await client.futures.brent().latest();
+console.log(`Brent: $${brent.price}`);
+
+// ICE Gasoil
+const gasoil = await client.futures.gasoil().curve();
+
+// ICE WTI
+const wti = await client.futures.wti().ohlc("2024-01-15");
+
+// Natural gas families
+await client.futures.naturalGas().latest(); // Henry Hub
+await client.futures.ttfGas().historical({ startDate: "2024-01-01" }); // TTF (Europe)
+await client.futures.lngJkm().spreads(); // LNG JKM (Asia)
+
+// Carbon
+await client.futures.euaCarbon().latest(); // EU carbon allowance
+await client.futures.ukCarbon().spreadHistory(); // UK carbon allowance
+
+// Or address a family by slug
+const fam = client.futures.family("ice-brent");
+await fam.intraday();
+
+// Ergonomic contract-code constants for the generic methods
+const brentLatest = await client.futures.latest(FUTURES_CONTRACTS.BRENT); // "BZ"
+const gasoilCode = FUTURES_CONTRACTS.GASOIL; // "G"
+```
+
+Available families: `ice-brent`, `ice-gasoil`, `ice-wti`, `natural-gas`,
+`ttf-gas`, `lng-jkm`, `eua-carbon`, `uk-carbon`.
+
+### Spreads
+
+Crack spreads, basis differentials, curve structure (contango/backwardation),
+refining margins, and physical premiums. Each spread type supports the latest
+value, full history, and an `all` listing
+(`/v1/spreads/{type}`, `/v1/spreads/{type}/historical`, `/v1/spreads/{type}/all`).
+
+```typescript
+// Latest values via named helpers
+const crack = await client.spreads.crack();
+console.log(`Crack spread: ${crack.value} ${crack.unit}`);
+
+await client.spreads.basis();
+await client.spreads.curveStructure();
+await client.spreads.margin();
+await client.spreads.physicalPremium();
+
+// Or address a type directly
+const margin = await client.spreads.get("margin");
+
+// Historical spread series
+const history = await client.spreads.historical("basis", {
+  startDate: "2024-01-01",
+  endDate: "2024-12-31",
+});
+
+// All values for a spread type
+const allCrack = await client.spreads.all("crack");
+```
+
+### Indicators
+
+Derived market indicators and signals: fuel-switching economics, price context,
+storage analytics, market annotations, CFTC positioning, and congressional
+energy-sector trades (`/v1/indicators/{type}`).
+
+```typescript
+// Fuel-switching economics
+const fs = await client.indicators.fuelSwitching();
+console.log(`Switching economical: ${fs.economical}`);
+
+// Where the current price sits historically
+const ctx = await client.indicators.priceContext();
+console.log(`Percentile: ${ctx.percentile}`);
+
+// Storage analytics
+await client.indicators.storageAnalytics();
+
+// Market annotations (notable events)
+const annotations = await client.indicators.annotations();
+
+// CFTC positioning (Commitment of Traders)
+const cftc = await client.indicators.cftcPositioning();
+cftc.forEach((p) => console.log(`${p.market}: net ${p.net_position}`));
+
+// Congressional energy-sector trades
+const trades = await client.indicators.congressionalTrades();
+
+// Or address a type directly
+const custom = await client.indicators.get("price-context");
+```
+
+### Raw HTTP responses (status + headers)
+
+By default the SDK returns just the parsed data. When you also need the
+underlying HTTP status code and response headers (e.g. rate-limit headers),
+use the `client.raw.*` accessor. It returns `{ data, status, headers }` while
+`data` keeps the exact same shape as the equivalent non-raw method.
+
+```typescript
+const { data, status, headers } = await client.raw.getLatestPrices({
+  commodity: "WTI_USD",
+});
+
+console.log(`HTTP ${status}`);
+console.log(`Rate limit remaining: ${headers.get("x-ratelimit-remaining")}`);
+console.log(`Price: ${data[0].price}`);
+
+// Also available: getHistoricalPrices, getCommodities,
+// getCommodityCategories, getCommodity
+const commodities = await client.raw.getCommodities();
+console.log(commodities.status, commodities.headers.get("content-type"));
+
+// Generic raw GET for any endpoint without a dedicated helper
+const futures = await client.raw.get("/v1/futures/CL.1");
+console.log(futures.status, futures.data);
+```
+
 ### Storage Levels (New in v0.7.0)
 
 ```typescript
@@ -383,11 +514,7 @@ console.log(`30-day return: ${perf.return_percent}%`);
 console.log(`Volatility: ${perf.volatility}`);
 
 // Analyze correlation between commodities
-const corr = await client.analytics.correlation(
-  "WTI_USD",
-  "BRENT_CRUDE_USD",
-  90,
-);
+const corr = await client.analytics.correlation("WTI_USD", "BRENT_CRUDE_USD", 90);
 console.log(`Correlation: ${corr.correlation} (${corr.strength})`);
 ```
 
@@ -510,9 +637,7 @@ console.log(`Connection ${test.success ? "OK" : "failed"}`);
 // View sync logs
 const logs = await client.dataSources.logs(source.id);
 logs.forEach((log) => {
-  console.log(
-    `${log.timestamp}: ${log.status} - ${log.records_synced} records`,
-  );
+  console.log(`${log.timestamp}: ${log.status} - ${log.records_synced} records`);
 });
 ```
 
@@ -557,11 +682,7 @@ try {
   if (error instanceof AuthenticationError) {
     console.error("Invalid API key:", error.message);
   } else if (error instanceof RateLimitError) {
-    console.error(
-      "Rate limit exceeded. Retry after:",
-      error.retryAfter,
-      "seconds",
-    );
+    console.error("Rate limit exceeded. Retry after:", error.retryAfter, "seconds");
   } else if (error instanceof TimeoutError) {
     console.error("Request timed out:", error.message);
   } else if (error instanceof ServerError) {
@@ -812,9 +933,7 @@ const result = await client.diesel.getStations({
 console.log(`Found ${result.stations.length} stations`);
 console.log(`Regional average: $${result.regional_average.price}/gallon`);
 
-const cheapest = result.stations.reduce((min, s) =>
-  s.diesel_price < min.diesel_price ? s : min,
-);
+const cheapest = result.stations.reduce((min, s) => (s.diesel_price < min.diesel_price ? s : min));
 console.log(`Cheapest: ${cheapest.name} at ${cheapest.formatted_price}`);
 ```
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,6 +33,26 @@ import { EnergyIntelligenceResource } from "./resources/ei/index.js";
 import { WebhooksResource } from "./resources/webhooks.js";
 import { DataSourcesResource } from "./resources/data-sources.js";
 import { SDK_VERSION, SDK_NAME, buildUserAgent } from "./version.js";
+import { SpreadsResource } from "./resources/spreads.js";
+import { IndicatorsResource } from "./resources/indicators.js";
+import { RawResource } from "./resources/raw.js";
+
+/**
+ * Raw HTTP response wrapper.
+ *
+ * Returned by {@link OilPriceAPI.raw} accessors to expose the underlying
+ * HTTP status code and response headers alongside the parsed data.
+ *
+ * @typeParam T - The parsed response body type.
+ */
+export interface APIResponse<T> {
+  /** Parsed response data (same shape the non-raw method would return). */
+  data: T;
+  /** HTTP status code (e.g., 200, 201). */
+  status: number;
+  /** Response headers. */
+  headers: Headers;
+}
 
 /**
  * Official Node.js client for Oil Price API
@@ -141,6 +161,25 @@ export class OilPriceAPI {
    */
   public readonly dataSources: DataSourcesResource;
 
+  /**
+   * Spreads resource (crack, basis, curve structure, margin, physical premium)
+   */
+  public readonly spreads: SpreadsResource;
+
+  /**
+   * Indicators resource (fuel switching, price context, storage analytics,
+   * annotations, CFTC positioning, congressional trades)
+   */
+  public readonly indicators: IndicatorsResource;
+
+  /**
+   * Raw-response accessor.
+   *
+   * Mirrors the top-level price/commodity methods but returns the underlying
+   * HTTP status and headers alongside the parsed data via {@link APIResponse}.
+   */
+  public readonly raw: RawResource;
+
   constructor(config: OilPriceAPIConfig = {}) {
     this.apiKey = config.apiKey || process.env.OILPRICEAPI_KEY || "";
     if (!this.apiKey) {
@@ -172,6 +211,9 @@ export class OilPriceAPI {
     this.ei = new EnergyIntelligenceResource(this);
     this.webhooks = new WebhooksResource(this);
     this.dataSources = new DataSourcesResource(this);
+    this.spreads = new SpreadsResource(this);
+    this.indicators = new IndicatorsResource(this);
+    this.raw = new RawResource(this);
   }
 
   /**
@@ -235,6 +277,35 @@ export class OilPriceAPI {
   }
 
   /**
+   * Shape a parsed JSON response body into the value returned to callers.
+   *
+   * Centralizes the response-structure handling so that both {@link request}
+   * and {@link requestRaw} return identical data. Handles the latest/historical
+   * envelope shapes as well as the generic `{ data }` fallback used by resource
+   * mutations, alerts, webhooks, etc.
+   */
+  private shapeResponseData<T>(responseData: any): T {
+    // Handle different response structures
+    // Latest endpoint: { status, data: { price, ... } }
+    // Historical endpoint: { status, data: { prices: [...] } }
+    if (responseData.status === "success" && responseData.data) {
+      if (responseData.data.prices) {
+        // Historical endpoint - return prices array
+        this.log(`Returning ${responseData.data.prices.length} prices`);
+        return responseData.data.prices as T;
+      } else if (responseData.data.price !== undefined) {
+        // Latest endpoint - wrap single price in array
+        this.log("Returning single price (wrapped in array)");
+        return [responseData.data] as T;
+      }
+    }
+
+    // Fallback - return data as-is (used by resource mutations, alerts, webhooks, etc.)
+    this.log("Returning data as-is");
+    return (responseData.data !== undefined ? responseData.data : responseData) as T;
+  }
+
+  /**
    * Internal method to make HTTP requests with retry and timeout.
    * Supports all HTTP methods (GET, POST, PATCH, DELETE) with consistent
    * retry logic, timeout handling, and typed error responses.
@@ -244,6 +315,22 @@ export class OilPriceAPI {
     params?: Record<string, string>,
     options?: { method?: string; body?: unknown },
   ): Promise<T> {
+    const { data } = await this.requestRaw<T>(endpoint, params, options);
+    return data;
+  }
+
+  /**
+   * Internal method identical to {@link request} but returns the underlying
+   * HTTP status and headers alongside the parsed data.
+   *
+   * Used by the public {@link raw} accessor to expose response metadata
+   * (issue #7) without changing the return shape of existing methods.
+   */
+  private async requestRaw<T>(
+    endpoint: string,
+    params?: Record<string, string>,
+    options?: { method?: string; body?: unknown },
+  ): Promise<APIResponse<T>> {
     // Build URL with query parameters
     const url = new URL(`${this.baseUrl}${endpoint}`);
     if (params) {
@@ -354,7 +441,11 @@ export class OilPriceAPI {
           const responseText = await response.text();
           if (!responseText) {
             this.log("Empty response body");
-            return {} as T;
+            return {
+              data: {} as T,
+              status: response.status,
+              headers: response.headers,
+            };
           }
 
           // Parse successful response
@@ -365,24 +456,11 @@ export class OilPriceAPI {
             hasData: !!responseData.data,
           });
 
-          // Handle different response structures
-          // Latest endpoint: { status, data: { price, ... } }
-          // Historical endpoint: { status, data: { prices: [...] } }
-          if (responseData.status === "success" && responseData.data) {
-            if (responseData.data.prices) {
-              // Historical endpoint - return prices array
-              this.log(`Returning ${responseData.data.prices.length} prices`);
-              return responseData.data.prices as T;
-            } else if (responseData.data.price !== undefined) {
-              // Latest endpoint - wrap single price in array
-              this.log("Returning single price (wrapped in array)");
-              return [responseData.data] as T;
-            }
-          }
-
-          // Fallback - return data as-is (used by resource mutations, alerts, webhooks, etc.)
-          this.log("Returning data as-is");
-          return (responseData.data !== undefined ? responseData.data : responseData) as T;
+          return {
+            data: this.shapeResponseData<T>(responseData),
+            status: response.status,
+            headers: response.headers,
+          };
         } catch (error) {
           // Handle abort (timeout)
           if (error instanceof Error && error.name === "AbortError") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
 export { OilPriceAPI } from "./client.js";
+export type { APIResponse } from "./client.js";
 export { SDK_VERSION, SDK_NAME } from "./version.js";
 export type {
   OilPriceAPIConfig,
@@ -49,7 +50,33 @@ export type {
   FuturesCurveData,
   ContinuousContractPrice,
   ContinuousFuturesData,
+  FuturesSpreadHistoryPoint,
+  FuturesSpreadHistory,
+  FuturesContractFamilySlug,
 } from "./resources/futures.js";
+export {
+  FUTURES_CONTRACTS,
+  FUTURES_FAMILY_SLUGS,
+  FuturesContractFamily,
+} from "./resources/futures.js";
+export type {
+  SpreadType,
+  SpreadValue,
+  HistoricalSpreadValue,
+  HistoricalSpreadOptions,
+} from "./resources/spreads.js";
+export { SpreadsResource } from "./resources/spreads.js";
+export type {
+  IndicatorType,
+  FuelSwitchingIndicator,
+  PriceContextIndicator,
+  StorageAnalyticsIndicator,
+  AnnotationIndicator,
+  CFTCPositioningIndicator,
+  CongressionalTradeIndicator,
+} from "./resources/indicators.js";
+export { IndicatorsResource } from "./resources/indicators.js";
+export { RawResource } from "./resources/raw.js";
 export type {
   StorageData,
   HistoricalStorageData,

--- a/src/resources/futures.ts
+++ b/src/resources/futures.ts
@@ -167,6 +167,189 @@ export interface ContinuousFuturesData {
 }
 
 /**
+ * Spread-history data point for a contract family.
+ */
+export interface FuturesSpreadHistoryPoint {
+  /** ISO date */
+  date: string;
+  /** Spread value */
+  spread: number;
+  /** Optional percentage spread */
+  spread_percent?: number;
+}
+
+/**
+ * Spread-history data for a contract family.
+ */
+export interface FuturesSpreadHistory {
+  /** Contract family slug (e.g., "ice-brent") */
+  family: string;
+  /** Array of historical spread points */
+  history: FuturesSpreadHistoryPoint[];
+}
+
+/**
+ * Slugs for the supported ICE / gas / carbon futures contract families.
+ *
+ * These map to the `GET /v1/futures/{slug}/...` endpoints. Each family
+ * supports `/latest`, `/historical`, `/ohlc`, `/intraday`, `/spreads`,
+ * `/curve`, and `/spread-history`.
+ */
+export type FuturesContractFamilySlug =
+  | "ice-brent"
+  | "ice-gasoil"
+  | "ice-wti"
+  | "natural-gas"
+  | "ttf-gas"
+  | "lng-jkm"
+  | "eua-carbon"
+  | "uk-carbon";
+
+/**
+ * Ergonomic contract codes for the most-requested futures families (issue #1).
+ *
+ * Use with the generic {@link FuturesResource} methods, or use the typed
+ * {@link FuturesResource.family} helper for direct access to a family's
+ * endpoints.
+ *
+ * @example
+ * ```typescript
+ * import { FUTURES_CONTRACTS } from 'oilpriceapi';
+ *
+ * const brent = await client.futures.latest(FUTURES_CONTRACTS.BRENT); // "BZ"
+ * const gasoil = await client.futures.family('ice-gasoil').latest();
+ * ```
+ */
+export const FUTURES_CONTRACTS = {
+  /** ICE Brent crude */
+  BRENT: "BZ",
+  /** NYMEX WTI crude */
+  WTI: "CL",
+  /** ICE Gasoil */
+  GASOIL: "G",
+  /** Henry Hub natural gas */
+  NATURAL_GAS: "NG",
+  /** TTF natural gas (Europe) */
+  TTF_GAS: "TTF",
+  /** LNG JKM (Asia) */
+  LNG_JKM: "JKM",
+  /** EU carbon allowance */
+  EUA_CARBON: "EUA",
+  /** UK carbon allowance */
+  UK_CARBON: "UKA",
+} as const;
+
+/**
+ * Mapping of ergonomic contract codes to their API contract-family slugs.
+ *
+ * Lets you resolve a contract code (e.g., `"BZ"`) to the `/v1/futures/{slug}`
+ * path segment used by the typed family helpers.
+ */
+export const FUTURES_FAMILY_SLUGS: Record<string, FuturesContractFamilySlug> = {
+  [FUTURES_CONTRACTS.BRENT]: "ice-brent",
+  [FUTURES_CONTRACTS.WTI]: "ice-wti",
+  [FUTURES_CONTRACTS.GASOIL]: "ice-gasoil",
+  [FUTURES_CONTRACTS.NATURAL_GAS]: "natural-gas",
+  [FUTURES_CONTRACTS.TTF_GAS]: "ttf-gas",
+  [FUTURES_CONTRACTS.LNG_JKM]: "lng-jkm",
+  [FUTURES_CONTRACTS.EUA_CARBON]: "eua-carbon",
+  [FUTURES_CONTRACTS.UK_CARBON]: "uk-carbon",
+};
+
+/**
+ * Typed helper for a single futures contract family (e.g., ICE Brent, Gasoil).
+ *
+ * Provides ergonomic access to the family's endpoints without having to
+ * remember the URL slug. Obtain an instance via {@link FuturesResource.family},
+ * {@link FuturesResource.brent}, {@link FuturesResource.gasoil}, etc.
+ *
+ * @example
+ * ```typescript
+ * const gasoil = client.futures.gasoil();
+ * const latest = await gasoil.latest();
+ * const curve = await gasoil.curve();
+ * ```
+ */
+export class FuturesContractFamily {
+  constructor(
+    private client: OilPriceAPI,
+    /** The contract-family slug used in the API path. */
+    public readonly slug: FuturesContractFamilySlug,
+  ) {}
+
+  /**
+   * Get the latest price for this contract family.
+   */
+  async latest(): Promise<FuturesPrice> {
+    return this.client["request"]<FuturesPrice>(`/v1/futures/${this.slug}/latest`, {});
+  }
+
+  /**
+   * Get historical prices for this contract family.
+   *
+   * @param options - Optional date range filters.
+   */
+  async historical(options?: HistoricalFuturesOptions): Promise<HistoricalFuturesPrice[]> {
+    const params: Record<string, string> = {};
+    if (options?.startDate) params.start_date = options.startDate;
+    if (options?.endDate) params.end_date = options.endDate;
+
+    const response = await this.client["request"]<
+      HistoricalFuturesPrice[] | { prices: HistoricalFuturesPrice[] }
+    >(`/v1/futures/${this.slug}/historical`, params);
+
+    return Array.isArray(response) ? response : response.prices;
+  }
+
+  /**
+   * Get OHLC data for this contract family.
+   *
+   * @param date - Optional date (YYYY-MM-DD); defaults to latest.
+   */
+  async ohlc(date?: string): Promise<FuturesOHLC> {
+    const params: Record<string, string> = {};
+    if (date) params.date = date;
+    return this.client["request"]<FuturesOHLC>(`/v1/futures/${this.slug}/ohlc`, params);
+  }
+
+  /**
+   * Get intraday price data for this contract family.
+   */
+  async intraday(): Promise<IntradayFuturesData> {
+    return this.client["request"]<IntradayFuturesData>(`/v1/futures/${this.slug}/intraday`, {});
+  }
+
+  /**
+   * Get the spreads for this contract family.
+   */
+  async spreads(): Promise<FuturesSpread[]> {
+    const response = await this.client["request"]<FuturesSpread[] | { data: FuturesSpread[] }>(
+      `/v1/futures/${this.slug}/spreads`,
+      {},
+    );
+
+    return Array.isArray(response) ? response : response.data;
+  }
+
+  /**
+   * Get the forward curve for this contract family.
+   */
+  async curve(): Promise<FuturesCurveData> {
+    return this.client["request"]<FuturesCurveData>(`/v1/futures/${this.slug}/curve`, {});
+  }
+
+  /**
+   * Get historical spread data for this contract family.
+   */
+  async spreadHistory(): Promise<FuturesSpreadHistory> {
+    return this.client["request"]<FuturesSpreadHistory>(
+      `/v1/futures/${this.slug}/spread-history`,
+      {},
+    );
+  }
+}
+
+/**
  * Futures Resource
  *
  * Access futures contract data including latest, historical, OHLC, intraday,
@@ -284,10 +467,7 @@ export class FuturesResource {
     const params: Record<string, string> = {};
     if (date) params.date = date;
 
-    return this.client["request"]<FuturesOHLC>(
-      `/v1/futures/${contract}/ohlc`,
-      params,
-    );
+    return this.client["request"]<FuturesOHLC>(`/v1/futures/${contract}/ohlc`, params);
   }
 
   /**
@@ -314,10 +494,7 @@ export class FuturesResource {
       throw new ValidationError("Contract symbol must be a non-empty string");
     }
 
-    return this.client["request"]<IntradayFuturesData>(
-      `/v1/futures/${contract}/intraday`,
-      {},
-    );
+    return this.client["request"]<IntradayFuturesData>(`/v1/futures/${contract}/intraday`, {});
   }
 
   /**
@@ -378,10 +555,7 @@ export class FuturesResource {
       throw new ValidationError("Contract symbol must be a non-empty string");
     }
 
-    return this.client["request"]<FuturesCurveData>(
-      `/v1/futures/${contract}/curve`,
-      {},
-    );
+    return this.client["request"]<FuturesCurveData>(`/v1/futures/${contract}/curve`, {});
   }
 
   /**
@@ -403,10 +577,7 @@ export class FuturesResource {
    * console.log(`${continuous.prices.length} data points`);
    * ```
    */
-  async continuous(
-    contract: string,
-    months?: number,
-  ): Promise<ContinuousFuturesData> {
+  async continuous(contract: string, months?: number): Promise<ContinuousFuturesData> {
     if (!contract || typeof contract !== "string") {
       throw new ValidationError("Contract symbol must be a non-empty string");
     }
@@ -418,5 +589,69 @@ export class FuturesResource {
       `/v1/futures/${contract}/continuous`,
       params,
     );
+  }
+
+  /**
+   * Get a typed helper for a specific contract family (issue #1).
+   *
+   * Provides ergonomic access to the ICE Brent / WTI / Gasoil and gas/carbon
+   * family endpoints (`/latest`, `/historical`, `/ohlc`, `/intraday`,
+   * `/spreads`, `/curve`, `/spread-history`) without remembering the URL slug.
+   *
+   * @param slug - Contract family slug (e.g., `"ice-brent"`, `"ice-gasoil"`).
+   * @returns A {@link FuturesContractFamily} bound to the slug.
+   *
+   * @example
+   * ```typescript
+   * const brent = client.futures.family('ice-brent');
+   * const latest = await brent.latest();
+   * const curve = await brent.curve();
+   * ```
+   */
+  family(slug: FuturesContractFamilySlug): FuturesContractFamily {
+    if (!slug || typeof slug !== "string") {
+      throw new ValidationError("Contract family slug must be a non-empty string");
+    }
+    return new FuturesContractFamily(this.client, slug);
+  }
+
+  /** ICE Brent crude futures family helper (issue #1). */
+  brent(): FuturesContractFamily {
+    return this.family("ice-brent");
+  }
+
+  /** ICE WTI crude futures family helper. */
+  wti(): FuturesContractFamily {
+    return this.family("ice-wti");
+  }
+
+  /** ICE Gasoil futures family helper (issue #1). */
+  gasoil(): FuturesContractFamily {
+    return this.family("ice-gasoil");
+  }
+
+  /** Henry Hub natural gas futures family helper. */
+  naturalGas(): FuturesContractFamily {
+    return this.family("natural-gas");
+  }
+
+  /** TTF natural gas (Europe) futures family helper. */
+  ttfGas(): FuturesContractFamily {
+    return this.family("ttf-gas");
+  }
+
+  /** LNG JKM (Asia) futures family helper. */
+  lngJkm(): FuturesContractFamily {
+    return this.family("lng-jkm");
+  }
+
+  /** EU carbon allowance (EUA) futures family helper. */
+  euaCarbon(): FuturesContractFamily {
+    return this.family("eua-carbon");
+  }
+
+  /** UK carbon allowance (UKA) futures family helper. */
+  ukCarbon(): FuturesContractFamily {
+    return this.family("uk-carbon");
   }
 }

--- a/src/resources/indicators.ts
+++ b/src/resources/indicators.ts
@@ -1,0 +1,221 @@
+/**
+ * Indicators Resource
+ *
+ * Access derived market indicators and signals: fuel-switching economics,
+ * price context, storage analytics, market annotations, CFTC positioning, and
+ * congressional energy-sector trades.
+ */
+
+import type { OilPriceAPI } from "../client.js";
+import { ValidationError } from "../errors.js";
+
+/**
+ * Supported indicator types.
+ */
+export type IndicatorType =
+  | "fuel-switching"
+  | "price-context"
+  | "storage-analytics"
+  | "annotations"
+  | "cftc-positioning"
+  | "congressional-trades";
+
+/**
+ * Fuel-switching economics indicator.
+ */
+export interface FuelSwitchingIndicator {
+  /** Switching ratio or breakeven value */
+  value: number;
+  /** Whether switching is economical */
+  economical?: boolean;
+  /** From fuel (e.g., "gas") */
+  from_fuel?: string;
+  /** To fuel (e.g., "oil") */
+  to_fuel?: string;
+  /** Unit */
+  unit?: string;
+  /** ISO timestamp */
+  timestamp: string;
+  /** Additional metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Price-context indicator (where the current price sits historically).
+ */
+export interface PriceContextIndicator {
+  /** Commodity code */
+  commodity?: string;
+  /** Current price */
+  price: number;
+  /** Percentile vs trailing window */
+  percentile?: number;
+  /** 52-week high */
+  high_52w?: number;
+  /** 52-week low */
+  low_52w?: number;
+  /** ISO timestamp */
+  timestamp: string;
+  /** Additional metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Storage-analytics indicator.
+ */
+export interface StorageAnalyticsIndicator {
+  /** Storage level */
+  level: number;
+  /** Capacity utilization percentage */
+  capacity_percent?: number;
+  /** Days of cover */
+  days_of_cover?: number;
+  /** Z-score vs 5-year average */
+  zscore?: number;
+  /** Unit */
+  unit?: string;
+  /** ISO timestamp */
+  timestamp: string;
+  /** Additional metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Market annotation (notable event marker).
+ */
+export interface AnnotationIndicator {
+  /** Annotation ID */
+  id?: string;
+  /** Title */
+  title: string;
+  /** Description */
+  description?: string;
+  /** Category (e.g., "geopolitical", "supply", "demand") */
+  category?: string;
+  /** Event date */
+  date: string;
+  /** Related commodity */
+  commodity?: string;
+  /** Additional metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * CFTC positioning indicator (Commitment of Traders).
+ */
+export interface CFTCPositioningIndicator {
+  /** Market / commodity */
+  market?: string;
+  /** Managed-money long contracts */
+  managed_money_long?: number;
+  /** Managed-money short contracts */
+  managed_money_short?: number;
+  /** Net positioning */
+  net_position?: number;
+  /** Report date */
+  report_date: string;
+  /** Additional metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Congressional trade indicator (energy-sector disclosures).
+ */
+export interface CongressionalTradeIndicator {
+  /** Representative or senator name */
+  member?: string;
+  /** Ticker traded */
+  ticker?: string;
+  /** Transaction type ("buy" / "sell") */
+  transaction_type?: string;
+  /** Amount range */
+  amount_range?: string;
+  /** Transaction date */
+  transaction_date: string;
+  /** Disclosure date */
+  disclosure_date?: string;
+  /** Additional metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Indicators Resource
+ *
+ * @example
+ * ```typescript
+ * import { OilPriceAPI } from 'oilpriceapi';
+ *
+ * const client = new OilPriceAPI({ apiKey: 'your_key' });
+ *
+ * // Fuel-switching economics
+ * const fs = await client.indicators.fuelSwitching();
+ * console.log(`Switching economical: ${fs.economical}`);
+ *
+ * // CFTC positioning
+ * const cftc = await client.indicators.cftcPositioning();
+ * cftc.forEach(p => console.log(`${p.market}: net ${p.net_position}`));
+ *
+ * // Congressional trades
+ * const trades = await client.indicators.congressionalTrades();
+ * ```
+ */
+export class IndicatorsResource {
+  constructor(private client: OilPriceAPI) {}
+
+  /**
+   * Get an arbitrary indicator by type.
+   *
+   * @typeParam T - Expected response type.
+   * @param type - Indicator type slug.
+   * @returns The indicator data.
+   * @throws {ValidationError} If the type is invalid.
+   */
+  async get<T = unknown>(type: IndicatorType): Promise<T> {
+    if (!type || typeof type !== "string") {
+      throw new ValidationError("Indicator type must be a non-empty string");
+    }
+    return this.client["request"]<T>(`/v1/indicators/${type}`, {});
+  }
+
+  /** Fuel-switching economics indicator. */
+  async fuelSwitching(): Promise<FuelSwitchingIndicator> {
+    return this.get<FuelSwitchingIndicator>("fuel-switching");
+  }
+
+  /** Price-context indicator. */
+  async priceContext(): Promise<PriceContextIndicator> {
+    return this.get<PriceContextIndicator>("price-context");
+  }
+
+  /** Storage-analytics indicator. */
+  async storageAnalytics(): Promise<StorageAnalyticsIndicator> {
+    return this.get<StorageAnalyticsIndicator>("storage-analytics");
+  }
+
+  /** Market annotations. */
+  async annotations(): Promise<AnnotationIndicator[]> {
+    const response = await this.client["request"]<
+      AnnotationIndicator[] | { data: AnnotationIndicator[] }
+    >("/v1/indicators/annotations", {});
+
+    return Array.isArray(response) ? response : response.data;
+  }
+
+  /** CFTC positioning (Commitment of Traders) indicators. */
+  async cftcPositioning(): Promise<CFTCPositioningIndicator[]> {
+    const response = await this.client["request"]<
+      CFTCPositioningIndicator[] | { data: CFTCPositioningIndicator[] }
+    >("/v1/indicators/cftc-positioning", {});
+
+    return Array.isArray(response) ? response : response.data;
+  }
+
+  /** Congressional energy-sector trade indicators. */
+  async congressionalTrades(): Promise<CongressionalTradeIndicator[]> {
+    const response = await this.client["request"]<
+      CongressionalTradeIndicator[] | { data: CongressionalTradeIndicator[] }
+    >("/v1/indicators/congressional-trades", {});
+
+    return Array.isArray(response) ? response : response.data;
+  }
+}

--- a/src/resources/raw.ts
+++ b/src/resources/raw.ts
@@ -1,0 +1,136 @@
+/**
+ * Raw Response Resource
+ *
+ * Provides opt-in access to the underlying HTTP status code and response
+ * headers alongside the parsed data. Mirrors the most commonly used top-level
+ * client methods. This is the #1 requested enhancement (issue #7).
+ *
+ * @example
+ * ```typescript
+ * import { OilPriceAPI } from 'oilpriceapi';
+ *
+ * const client = new OilPriceAPI({ apiKey: 'your_key' });
+ *
+ * const { data, status, headers } = await client.raw.getLatestPrices();
+ * console.log(`HTTP ${status}`);
+ * console.log(`Rate limit remaining: ${headers.get('x-ratelimit-remaining')}`);
+ * console.log(data[0].price);
+ * ```
+ */
+
+import type { OilPriceAPI, APIResponse } from "../client.js";
+import type {
+  Price,
+  LatestPricesOptions,
+  HistoricalPricesOptions,
+  Commodity,
+  CommoditiesResponse,
+  CategoriesResponse,
+} from "../types.js";
+
+/**
+ * Raw Response Resource
+ *
+ * Each method returns an {@link APIResponse} with `{ data, status, headers }`
+ * instead of just the parsed data, so callers can inspect HTTP metadata such
+ * as rate-limit headers, caching headers, and the exact status code.
+ */
+export class RawResource {
+  constructor(private client: OilPriceAPI) {}
+
+  /**
+   * Make an arbitrary GET request and return data plus HTTP status and headers.
+   *
+   * Use this for endpoints without a dedicated raw helper.
+   *
+   * @typeParam T - Expected parsed response type.
+   * @param endpoint - API path beginning with `/` (e.g. `/v1/prices/latest`).
+   * @param params - Optional query parameters.
+   * @returns The parsed data along with the HTTP status code and headers.
+   *
+   * @example
+   * ```typescript
+   * const { data, status, headers } = await client.raw.get('/v1/futures/CL.1');
+   * ```
+   */
+  async get<T = unknown>(
+    endpoint: string,
+    params?: Record<string, string>,
+  ): Promise<APIResponse<T>> {
+    return this.client["requestRaw"]<T>(endpoint, params);
+  }
+
+  /**
+   * Latest prices with raw HTTP status and headers.
+   *
+   * @param options - Optional commodity filter.
+   * @returns Prices array with HTTP status and headers.
+   *
+   * @example
+   * ```typescript
+   * const { data, status, headers } = await client.raw.getLatestPrices({ commodity: 'WTI_USD' });
+   * ```
+   */
+  async getLatestPrices(options?: LatestPricesOptions): Promise<APIResponse<Price[]>> {
+    const params: Record<string, string> = {};
+    if (options?.commodity) {
+      params.by_code = options.commodity;
+    }
+    return this.client["requestRaw"]<Price[]>("/v1/prices/latest", params);
+  }
+
+  /**
+   * Historical prices with raw HTTP status and headers.
+   *
+   * @param options - Time period and filter options.
+   * @returns Prices array with HTTP status and headers.
+   *
+   * @example
+   * ```typescript
+   * const { data, status, headers } = await client.raw.getHistoricalPrices({
+   *   period: 'past_week',
+   *   commodity: 'BRENT_CRUDE_USD',
+   * });
+   * ```
+   */
+  async getHistoricalPrices(options?: HistoricalPricesOptions): Promise<APIResponse<Price[]>> {
+    const params: Record<string, string> = {};
+    if (options?.period) params.period = options.period;
+    if (options?.commodity) params.by_code = options.commodity;
+    if (options?.startDate) params.start_date = options.startDate;
+    if (options?.endDate) params.end_date = options.endDate;
+    if (options?.interval) params.interval = options.interval;
+    if (options?.perPage !== undefined) params.per_page = options.perPage.toString();
+    if (options?.page !== undefined) params.page = options.page.toString();
+
+    return this.client["requestRaw"]<Price[]>("/v1/prices/past_year", params);
+  }
+
+  /**
+   * Commodities metadata with raw HTTP status and headers.
+   *
+   * @returns Commodities response with HTTP status and headers.
+   */
+  async getCommodities(): Promise<APIResponse<CommoditiesResponse>> {
+    return this.client["requestRaw"]<CommoditiesResponse>("/v1/commodities", {});
+  }
+
+  /**
+   * Commodity categories with raw HTTP status and headers.
+   *
+   * @returns Categories response with HTTP status and headers.
+   */
+  async getCommodityCategories(): Promise<APIResponse<CategoriesResponse>> {
+    return this.client["requestRaw"]<CategoriesResponse>("/v1/commodities/categories", {});
+  }
+
+  /**
+   * A single commodity's metadata with raw HTTP status and headers.
+   *
+   * @param code - Commodity code (e.g., "WTI_USD").
+   * @returns Commodity with HTTP status and headers.
+   */
+  async getCommodity(code: string): Promise<APIResponse<Commodity>> {
+    return this.client["requestRaw"]<Commodity>(`/v1/commodities/${code}`, {});
+  }
+}

--- a/src/resources/spreads.ts
+++ b/src/resources/spreads.ts
@@ -1,0 +1,177 @@
+/**
+ * Spreads Resource
+ *
+ * Access oil & product spread analytics: crack spreads, basis spreads,
+ * curve-structure (contango/backwardation), refining margins, and physical
+ * premiums. Each spread type supports the latest value, full history, and an
+ * `all` listing.
+ */
+
+import type { OilPriceAPI } from "../client.js";
+import { ValidationError } from "../errors.js";
+
+/**
+ * Supported spread types.
+ *
+ * - `crack` — refining crack spread (e.g., 3:2:1)
+ * - `basis` — regional basis differential vs benchmark
+ * - `curve-structure` — contango / backwardation structure
+ * - `margin` — refining margin
+ * - `physical-premium` — physical-vs-paper premium
+ */
+export type SpreadType = "crack" | "basis" | "curve-structure" | "margin" | "physical-premium";
+
+/**
+ * A single spread data point.
+ */
+export interface SpreadValue {
+  /** Spread type slug */
+  type: string;
+  /** Spread name / label */
+  name?: string;
+  /** Spread value */
+  value: number;
+  /** Unit (e.g., "USD/bbl") */
+  unit?: string;
+  /** Region or market */
+  region?: string;
+  /** Benchmark or components */
+  components?: string[];
+  /** ISO timestamp */
+  timestamp: string;
+  /** Additional metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Historical spread data point.
+ */
+export interface HistoricalSpreadValue {
+  /** ISO date */
+  date: string;
+  /** Spread value */
+  value: number;
+  /** Unit */
+  unit?: string;
+}
+
+/**
+ * Options for a historical spread query.
+ */
+export interface HistoricalSpreadOptions {
+  /** Start date (YYYY-MM-DD) */
+  startDate?: string;
+  /** End date (YYYY-MM-DD) */
+  endDate?: string;
+}
+
+/**
+ * Spreads Resource
+ *
+ * @example
+ * ```typescript
+ * import { OilPriceAPI } from 'oilpriceapi';
+ *
+ * const client = new OilPriceAPI({ apiKey: 'your_key' });
+ *
+ * // Latest crack spread
+ * const crack = await client.spreads.crack();
+ * console.log(`Crack spread: ${crack.value} ${crack.unit}`);
+ *
+ * // Historical basis spreads
+ * const history = await client.spreads.historical('basis', {
+ *   startDate: '2024-01-01',
+ *   endDate: '2024-12-31',
+ * });
+ *
+ * // All margin spreads
+ * const all = await client.spreads.all('margin');
+ * ```
+ */
+export class SpreadsResource {
+  constructor(private client: OilPriceAPI) {}
+
+  /**
+   * Get the latest value for a spread type.
+   *
+   * @param type - Spread type slug.
+   * @returns Latest spread value.
+   * @throws {ValidationError} If the type is invalid.
+   */
+  async get(type: SpreadType): Promise<SpreadValue> {
+    this.validateType(type);
+    return this.client["request"]<SpreadValue>(`/v1/spreads/${type}`, {});
+  }
+
+  /**
+   * Get historical data for a spread type.
+   *
+   * @param type - Spread type slug.
+   * @param options - Optional date range filters.
+   * @returns Array of historical spread values.
+   */
+  async historical(
+    type: SpreadType,
+    options?: HistoricalSpreadOptions,
+  ): Promise<HistoricalSpreadValue[]> {
+    this.validateType(type);
+
+    const params: Record<string, string> = {};
+    if (options?.startDate) params.start_date = options.startDate;
+    if (options?.endDate) params.end_date = options.endDate;
+
+    const response = await this.client["request"]<
+      HistoricalSpreadValue[] | { data: HistoricalSpreadValue[] }
+    >(`/v1/spreads/${type}/historical`, params);
+
+    return Array.isArray(response) ? response : response.data;
+  }
+
+  /**
+   * Get all spread values for a spread type.
+   *
+   * @param type - Spread type slug.
+   * @returns Array of spread values.
+   */
+  async all(type: SpreadType): Promise<SpreadValue[]> {
+    this.validateType(type);
+
+    const response = await this.client["request"]<SpreadValue[] | { data: SpreadValue[] }>(
+      `/v1/spreads/${type}/all`,
+      {},
+    );
+
+    return Array.isArray(response) ? response : response.data;
+  }
+
+  /** Latest crack spread. */
+  async crack(): Promise<SpreadValue> {
+    return this.get("crack");
+  }
+
+  /** Latest basis spread. */
+  async basis(): Promise<SpreadValue> {
+    return this.get("basis");
+  }
+
+  /** Latest curve-structure (contango / backwardation). */
+  async curveStructure(): Promise<SpreadValue> {
+    return this.get("curve-structure");
+  }
+
+  /** Latest refining margin. */
+  async margin(): Promise<SpreadValue> {
+    return this.get("margin");
+  }
+
+  /** Latest physical premium. */
+  async physicalPremium(): Promise<SpreadValue> {
+    return this.get("physical-premium");
+  }
+
+  private validateType(type: SpreadType): void {
+    if (!type || typeof type !== "string") {
+      throw new ValidationError("Spread type must be a non-empty string");
+    }
+  }
+}

--- a/tests/resources/ei.test.ts
+++ b/tests/resources/ei.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { OilPriceAPI } from "../../src/client.js";
+
+/**
+ * Energy Intelligence (ei.*) unit tests.
+ *
+ * Mocks the private client.request and asserts each sub-resource method hits
+ * the correct endpoint, passes the right params, and unwraps list envelopes.
+ * Previously the entire ei.* namespace had zero test coverage.
+ */
+describe("EnergyIntelligenceResource (ei.*)", () => {
+  let client: OilPriceAPI;
+
+  beforeEach(() => {
+    client = new OilPriceAPI({ apiKey: "test_key_123" });
+    vi.clearAllMocks();
+  });
+
+  function spy(resolved: unknown) {
+    return vi.spyOn(client as any, "request").mockResolvedValue(resolved);
+  }
+
+  // -------------------------------------------------------------------------
+  // rigCounts
+  // -------------------------------------------------------------------------
+  describe("rigCounts", () => {
+    it("list() unwraps array directly", async () => {
+      const s = spy([{ id: "1", total_rigs: 600, date: "d", timestamp: "t" }]);
+      const r = await client.ei.rigCounts.list();
+      expect(s).toHaveBeenCalledWith("/v1/ei/rig_counts", {});
+      expect(r).toHaveLength(1);
+    });
+
+    it("list() unwraps { data } envelope", async () => {
+      spy({ data: [{ id: "1", total_rigs: 1, date: "d", timestamp: "t" }] });
+      const r = await client.ei.rigCounts.list();
+      expect(r).toHaveLength(1);
+    });
+
+    it("get() validates id and hits id endpoint", async () => {
+      await expect(client.ei.rigCounts.get("")).rejects.toThrow(
+        "Record ID must be a non-empty string",
+      );
+      const s = spy({ id: "abc", total_rigs: 1, date: "d", timestamp: "t" });
+      await client.ei.rigCounts.get("abc");
+      expect(s).toHaveBeenCalledWith("/v1/ei/rig_counts/abc", {});
+    });
+
+    it("latest/byBasin/byState/historical hit correct endpoints", async () => {
+      const s = spy([]);
+      spy({ id: "1", total_rigs: 1, date: "d", timestamp: "t" });
+      await client.ei.rigCounts.latest();
+      expect(s).toHaveBeenLastCalledWith("/v1/ei/rig_counts/latest", {});
+
+      spy([]);
+      await client.ei.rigCounts.byBasin();
+      await client.ei.rigCounts.byState();
+      await client.ei.rigCounts.historical();
+      const calls = (client as any).request.mock.calls.map((c: any[]) => c[0]);
+      expect(calls).toContain("/v1/ei/rig_counts/by_basin");
+      expect(calls).toContain("/v1/ei/rig_counts/by_state");
+      expect(calls).toContain("/v1/ei/rig_counts/historical");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // oilInventories
+  // -------------------------------------------------------------------------
+  describe("oilInventories", () => {
+    it("covers list/get/latest/summary/byProduct/historical/cushing", async () => {
+      const s = spy([]);
+      spy({ id: "1", level: 1, unit: "kb", date: "d", timestamp: "t" });
+
+      await client.ei.oilInventories.latest();
+      await client.ei.oilInventories.summary();
+      await client.ei.oilInventories.cushing();
+
+      spy([]);
+      await client.ei.oilInventories.list();
+      await client.ei.oilInventories.byProduct();
+      await client.ei.oilInventories.historical();
+
+      const calls = (client as any).request.mock.calls.map((c: any[]) => c[0]);
+      expect(calls).toContain("/v1/ei/oil_inventories/latest");
+      expect(calls).toContain("/v1/ei/oil_inventories/summary");
+      expect(calls).toContain("/v1/ei/oil_inventories/cushing");
+      expect(calls).toContain("/v1/ei/oil_inventories");
+      expect(calls).toContain("/v1/ei/oil_inventories/by_product");
+      expect(calls).toContain("/v1/ei/oil_inventories/historical");
+      expect(s).toBeDefined();
+    });
+
+    it("get() validates id", async () => {
+      await expect(client.ei.oilInventories.get("")).rejects.toThrow(
+        "Record ID must be a non-empty string",
+      );
+      const s = spy({ id: "x", level: 1, unit: "kb", date: "d", timestamp: "t" });
+      await client.ei.oilInventories.get("x");
+      expect(s).toHaveBeenCalledWith("/v1/ei/oil_inventories/x", {});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // opecProduction
+  // -------------------------------------------------------------------------
+  describe("opecProduction", () => {
+    it("covers list/get/latest/total/byCountry/historical/topProducers", async () => {
+      spy({ total_production_bpd: 1, unit: "bpd", as_of_date: "d" });
+      await client.ei.opecProduction.total();
+
+      spy({ id: "1", production_bpd: 1, unit: "bpd", date: "d", timestamp: "t" });
+      await client.ei.opecProduction.latest();
+
+      spy([]);
+      await client.ei.opecProduction.list();
+      await client.ei.opecProduction.byCountry();
+      await client.ei.opecProduction.historical();
+      await client.ei.opecProduction.topProducers();
+
+      const calls = (client as any).request.mock.calls.map((c: any[]) => c[0]);
+      expect(calls).toContain("/v1/ei/opec_productions/total");
+      expect(calls).toContain("/v1/ei/opec_productions/latest");
+      expect(calls).toContain("/v1/ei/opec_productions");
+      expect(calls).toContain("/v1/ei/opec_productions/by_country");
+      expect(calls).toContain("/v1/ei/opec_productions/historical");
+      expect(calls).toContain("/v1/ei/opec_productions/top_producers");
+    });
+
+    it("get() validates id", async () => {
+      await expect(client.ei.opecProduction.get("")).rejects.toThrow(
+        "Record ID must be a non-empty string",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // drillingProductivity
+  // -------------------------------------------------------------------------
+  describe("drillingProductivity", () => {
+    it("covers all methods", async () => {
+      spy({ id: "1", date: "d", timestamp: "t" });
+      await client.ei.drillingProductivity.latest();
+
+      spy({ as_of_date: "d" });
+      await client.ei.drillingProductivity.summary();
+
+      spy([]);
+      await client.ei.drillingProductivity.list();
+      await client.ei.drillingProductivity.ducWells();
+      await client.ei.drillingProductivity.byBasin();
+      await client.ei.drillingProductivity.historical();
+      await client.ei.drillingProductivity.trends();
+
+      const calls = (client as any).request.mock.calls.map((c: any[]) => c[0]);
+      expect(calls).toContain("/v1/ei/drilling_productivities/latest");
+      expect(calls).toContain("/v1/ei/drilling_productivities/summary");
+      expect(calls).toContain("/v1/ei/drilling_productivities");
+      expect(calls).toContain("/v1/ei/drilling_productivities/duc_wells");
+      expect(calls).toContain("/v1/ei/drilling_productivities/by_basin");
+      expect(calls).toContain("/v1/ei/drilling_productivities/historical");
+      expect(calls).toContain("/v1/ei/drilling_productivities/trends");
+    });
+
+    it("get() validates id", async () => {
+      await expect(client.ei.drillingProductivity.get("")).rejects.toThrow(
+        "Record ID must be a non-empty string",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // forecasts
+  // -------------------------------------------------------------------------
+  describe("forecasts", () => {
+    it("covers all methods", async () => {
+      spy({
+        id: "1",
+        forecast_value: 80,
+        published_date: "d",
+        timestamp: "t",
+      });
+      await client.ei.forecasts.latest();
+
+      spy({ total_forecasts: 1, as_of_date: "d" });
+      await client.ei.forecasts.summary();
+
+      spy([]);
+      await client.ei.forecasts.list();
+      await client.ei.forecasts.prices();
+      await client.ei.forecasts.production();
+      await client.ei.forecasts.historical();
+      await client.ei.forecasts.compare();
+
+      const calls = (client as any).request.mock.calls.map((c: any[]) => c[0]);
+      expect(calls).toContain("/v1/ei/forecasts/latest");
+      expect(calls).toContain("/v1/ei/forecasts/summary");
+      expect(calls).toContain("/v1/ei/forecasts");
+      expect(calls).toContain("/v1/ei/forecasts/prices");
+      expect(calls).toContain("/v1/ei/forecasts/production");
+      expect(calls).toContain("/v1/ei/forecasts/historical");
+      expect(calls).toContain("/v1/ei/forecasts/compare");
+    });
+
+    it("get() validates id and hits endpoint", async () => {
+      await expect(client.ei.forecasts.get("")).rejects.toThrow(
+        "Record ID must be a non-empty string",
+      );
+      const s = spy({
+        id: "f1",
+        forecast_value: 1,
+        published_date: "d",
+        timestamp: "t",
+      });
+      await client.ei.forecasts.get("f1");
+      expect(s).toHaveBeenCalledWith("/v1/ei/forecasts/f1", {});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // wellPermits
+  // -------------------------------------------------------------------------
+  describe("wellPermits", () => {
+    it("covers list/latest/summary/byState/byOperator/byFormation", async () => {
+      spy({ id: "1", state: "TX", issue_date: "d", timestamp: "t" });
+      await client.ei.wellPermits.latest();
+
+      spy({ total_permits: 1, as_of_date: "d" });
+      await client.ei.wellPermits.summary();
+
+      spy([]);
+      await client.ei.wellPermits.list();
+      await client.ei.wellPermits.byState();
+      await client.ei.wellPermits.byOperator();
+      await client.ei.wellPermits.byFormation();
+
+      const calls = (client as any).request.mock.calls.map((c: any[]) => c[0]);
+      expect(calls).toContain("/v1/ei/well-permits/latest");
+      expect(calls).toContain("/v1/ei/well-permits/summary");
+      expect(calls).toContain("/v1/ei/well-permits");
+      expect(calls).toContain("/v1/ei/well-permits/by-state");
+      expect(calls).toContain("/v1/ei/well-permits/by-operator");
+      expect(calls).toContain("/v1/ei/well-permits/by-formation");
+    });
+
+    it("search() passes query params", async () => {
+      const s = spy([]);
+      await client.ei.wellPermits.search({
+        state: "Texas",
+        operator: "ConocoPhillips",
+        formation: "Wolfcamp",
+        start_date: "2024-01-01",
+        end_date: "2024-12-31",
+      });
+      expect(s).toHaveBeenCalledWith("/v1/ei/well-permits/search", {
+        state: "Texas",
+        operator: "ConocoPhillips",
+        formation: "Wolfcamp",
+        start_date: "2024-01-01",
+        end_date: "2024-12-31",
+      });
+    });
+
+    it("get() validates id", async () => {
+      await expect(client.ei.wellPermits.get("")).rejects.toThrow(
+        "Record ID must be a non-empty string",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // fracFocus
+  // -------------------------------------------------------------------------
+  describe("fracFocus", () => {
+    it("covers list/latest/summary/byState/byOperator/byChemical", async () => {
+      spy({ id: "1", api_number: "42", state: "TX", timestamp: "t" });
+      await client.ei.fracFocus.latest();
+
+      spy({ total_disclosures: 1, as_of_date: "d" });
+      await client.ei.fracFocus.summary();
+
+      spy([]);
+      await client.ei.fracFocus.list();
+      await client.ei.fracFocus.byState();
+      await client.ei.fracFocus.byOperator();
+      await client.ei.fracFocus.byChemical();
+
+      const calls = (client as any).request.mock.calls.map((c: any[]) => c[0]);
+      expect(calls).toContain("/v1/ei/frac-focus/latest");
+      expect(calls).toContain("/v1/ei/frac-focus/summary");
+      expect(calls).toContain("/v1/ei/frac-focus");
+      expect(calls).toContain("/v1/ei/frac-focus/by-state");
+      expect(calls).toContain("/v1/ei/frac-focus/by-operator");
+      expect(calls).toContain("/v1/ei/frac-focus/by-chemical");
+    });
+
+    it("search() passes query params", async () => {
+      const s = spy([]);
+      await client.ei.fracFocus.search({ state: "Texas", chemical: "HCl" });
+      expect(s).toHaveBeenCalledWith("/v1/ei/frac-focus/search", {
+        state: "Texas",
+        chemical: "HCl",
+      });
+    });
+
+    it("chemicals() validates id and unwraps { chemicals }", async () => {
+      await expect(client.ei.fracFocus.chemicals("")).rejects.toThrow(
+        "Disclosure ID must be a non-empty string",
+      );
+      const chems = [{ chemical_name: "Water" }];
+      const s = vi.spyOn(client as any, "request").mockResolvedValue({ chemicals: chems });
+      const r = await client.ei.fracFocus.chemicals("abc");
+      expect(s).toHaveBeenCalledWith("/v1/ei/frac-focus/abc/chemicals", {});
+      expect(r).toEqual(chems);
+    });
+
+    it("forWell() validates apiNumber and hits endpoint", async () => {
+      await expect(client.ei.fracFocus.forWell("")).rejects.toThrow(
+        "API number must be a non-empty string",
+      );
+      const s = spy([]);
+      await client.ei.fracFocus.forWell("42-123-12345");
+      expect(s).toHaveBeenCalledWith("/v1/ei/frac-focus/for-well/42-123-12345", {});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // wellTimeline (top-level ei method)
+  // -------------------------------------------------------------------------
+  describe("wellTimeline()", () => {
+    it("validates apiNumber", async () => {
+      await expect(client.ei.wellTimeline("")).rejects.toThrow(
+        "API number must be a non-empty string",
+      );
+    });
+
+    it("hits the well timeline endpoint", async () => {
+      const s = spy({ api_number: "42-123-12345", events: [] });
+      const r = await client.ei.wellTimeline("42-123-12345");
+      expect(s).toHaveBeenCalledWith("/v1/ei/wells/42-123-12345/timeline", {});
+      expect(r.api_number).toBe("42-123-12345");
+    });
+  });
+});

--- a/tests/resources/futures-family.test.ts
+++ b/tests/resources/futures-family.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { OilPriceAPI } from "../../src/client.js";
+import {
+  FUTURES_CONTRACTS,
+  FUTURES_FAMILY_SLUGS,
+  FuturesContractFamily,
+} from "../../src/resources/futures.js";
+
+/**
+ * Typed futures contract-family helper tests (issue #1).
+ *
+ * Verifies ergonomic ICE Brent / Gasoil / WTI and gas/carbon family helpers
+ * reach the correct endpoints.
+ */
+describe("Futures contract families (issue #1)", () => {
+  let client: OilPriceAPI;
+
+  beforeEach(() => {
+    client = new OilPriceAPI({ apiKey: "test_key_123" });
+    vi.clearAllMocks();
+  });
+
+  describe("FUTURES_CONTRACTS constants", () => {
+    it("exposes ICE Brent, WTI and Gasoil codes", () => {
+      expect(FUTURES_CONTRACTS.BRENT).toBe("BZ");
+      expect(FUTURES_CONTRACTS.WTI).toBe("CL");
+      expect(FUTURES_CONTRACTS.GASOIL).toBe("G");
+    });
+
+    it("maps codes to family slugs", () => {
+      expect(FUTURES_FAMILY_SLUGS[FUTURES_CONTRACTS.BRENT]).toBe("ice-brent");
+      expect(FUTURES_FAMILY_SLUGS[FUTURES_CONTRACTS.GASOIL]).toBe("ice-gasoil");
+      expect(FUTURES_FAMILY_SLUGS[FUTURES_CONTRACTS.TTF_GAS]).toBe("ttf-gas");
+      expect(FUTURES_FAMILY_SLUGS[FUTURES_CONTRACTS.EUA_CARBON]).toBe("eua-carbon");
+    });
+  });
+
+  describe("family() factory", () => {
+    it("returns a FuturesContractFamily bound to the slug", () => {
+      const fam = client.futures.family("ice-brent");
+      expect(fam).toBeInstanceOf(FuturesContractFamily);
+      expect(fam.slug).toBe("ice-brent");
+    });
+
+    it("throws for empty slug", () => {
+      expect(() => client.futures.family("" as any)).toThrow(
+        "Contract family slug must be a non-empty string",
+      );
+    });
+  });
+
+  describe("named family helpers map to correct slugs", () => {
+    it.each([
+      ["brent", "ice-brent"],
+      ["wti", "ice-wti"],
+      ["gasoil", "ice-gasoil"],
+      ["naturalGas", "natural-gas"],
+      ["ttfGas", "ttf-gas"],
+      ["lngJkm", "lng-jkm"],
+      ["euaCarbon", "eua-carbon"],
+      ["ukCarbon", "uk-carbon"],
+    ])("futures.%s() -> %s", (method, slug) => {
+      const fam = (client.futures as any)[method]();
+      expect(fam.slug).toBe(slug);
+    });
+  });
+
+  describe("family endpoint coverage", () => {
+    it("latest() hits /v1/futures/{slug}/latest", async () => {
+      const spy = vi
+        .spyOn(client as any, "request")
+        .mockResolvedValue({ contract: "ice-gasoil", price: 800, currency: "USD", timestamp: "t" });
+
+      await client.futures.gasoil().latest();
+
+      expect(spy).toHaveBeenCalledWith("/v1/futures/ice-gasoil/latest", {});
+    });
+
+    it("historical() passes date params", async () => {
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue([]);
+
+      await client.futures.brent().historical({
+        startDate: "2024-01-01",
+        endDate: "2024-01-31",
+      });
+
+      expect(spy).toHaveBeenCalledWith("/v1/futures/ice-brent/historical", {
+        start_date: "2024-01-01",
+        end_date: "2024-01-31",
+      });
+    });
+
+    it("historical() unwraps { prices } envelope", async () => {
+      const prices = [{ contract: "ice-brent", price: 1, timestamp: "t" }];
+      vi.spyOn(client as any, "request").mockResolvedValue({ prices });
+
+      const result = await client.futures.brent().historical();
+
+      expect(result).toEqual(prices);
+    });
+
+    it("ohlc() passes date param", async () => {
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue({});
+
+      await client.futures.wti().ohlc("2024-01-15");
+
+      expect(spy).toHaveBeenCalledWith("/v1/futures/ice-wti/ohlc", {
+        date: "2024-01-15",
+      });
+    });
+
+    it("intraday() hits /intraday", async () => {
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue({});
+      await client.futures.naturalGas().intraday();
+      expect(spy).toHaveBeenCalledWith("/v1/futures/natural-gas/intraday", {});
+    });
+
+    it("spreads() hits /spreads and unwraps { data }", async () => {
+      const data = [{ contract1: "a", contract2: "b", spread: 1, timestamp: "t" }];
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue({ data });
+
+      const result = await client.futures.ttfGas().spreads();
+
+      expect(spy).toHaveBeenCalledWith("/v1/futures/ttf-gas/spreads", {});
+      expect(result).toEqual(data);
+    });
+
+    it("curve() hits /curve", async () => {
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue({});
+      await client.futures.lngJkm().curve();
+      expect(spy).toHaveBeenCalledWith("/v1/futures/lng-jkm/curve", {});
+    });
+
+    it("spreadHistory() hits /spread-history", async () => {
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue({});
+      await client.futures.euaCarbon().spreadHistory();
+      expect(spy).toHaveBeenCalledWith("/v1/futures/eua-carbon/spread-history", {});
+    });
+  });
+});

--- a/tests/resources/indicators.test.ts
+++ b/tests/resources/indicators.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { OilPriceAPI } from "../../src/client.js";
+import type {
+  FuelSwitchingIndicator,
+  CFTCPositioningIndicator,
+  CongressionalTradeIndicator,
+  AnnotationIndicator,
+} from "../../src/resources/indicators.js";
+
+describe("IndicatorsResource", () => {
+  let client: OilPriceAPI;
+
+  beforeEach(() => {
+    client = new OilPriceAPI({ apiKey: "test_key_123" });
+    vi.clearAllMocks();
+  });
+
+  describe("get()", () => {
+    it("fetches an indicator by type", async () => {
+      const spy = vi
+        .spyOn(client as any, "request")
+        .mockResolvedValue({ value: 1, timestamp: "t" });
+
+      await client.indicators.get("price-context");
+
+      expect(spy).toHaveBeenCalledWith("/v1/indicators/price-context", {});
+    });
+
+    it("throws on empty type", async () => {
+      await expect(client.indicators.get("" as any)).rejects.toThrow(
+        "Indicator type must be a non-empty string",
+      );
+    });
+  });
+
+  describe("fuelSwitching()", () => {
+    it("fetches fuel-switching indicator", async () => {
+      const mock: FuelSwitchingIndicator = {
+        value: 1.2,
+        economical: true,
+        from_fuel: "gas",
+        to_fuel: "oil",
+        timestamp: "2024-01-15T10:00:00Z",
+      };
+
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue(mock);
+
+      const result = await client.indicators.fuelSwitching();
+
+      expect(spy).toHaveBeenCalledWith("/v1/indicators/fuel-switching", {});
+      expect(result).toEqual(mock);
+    });
+  });
+
+  describe("priceContext() / storageAnalytics()", () => {
+    it.each([
+      ["priceContext", "price-context"],
+      ["storageAnalytics", "storage-analytics"],
+    ])("%s() calls /v1/indicators/%s", async (method, slug) => {
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue({ timestamp: "t" });
+
+      await (client.indicators as any)[method]();
+
+      expect(spy).toHaveBeenCalledWith(`/v1/indicators/${slug}`, {});
+    });
+  });
+
+  describe("annotations()", () => {
+    it("fetches array of annotations", async () => {
+      const mock: AnnotationIndicator[] = [
+        { title: "OPEC cut", category: "supply", date: "2024-01-01" },
+      ];
+
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue(mock);
+
+      const result = await client.indicators.annotations();
+
+      expect(spy).toHaveBeenCalledWith("/v1/indicators/annotations", {});
+      expect(result).toEqual(mock);
+    });
+
+    it("unwraps { data } envelope", async () => {
+      const mock: AnnotationIndicator[] = [{ title: "x", date: "2024-01-01" }];
+      vi.spyOn(client as any, "request").mockResolvedValue({ data: mock });
+
+      const result = await client.indicators.annotations();
+
+      expect(result).toEqual(mock);
+    });
+  });
+
+  describe("cftcPositioning()", () => {
+    it("fetches CFTC positioning array", async () => {
+      const mock: CFTCPositioningIndicator[] = [
+        {
+          market: "WTI",
+          managed_money_long: 100,
+          managed_money_short: 50,
+          net_position: 50,
+          report_date: "2024-01-09",
+        },
+      ];
+
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue(mock);
+
+      const result = await client.indicators.cftcPositioning();
+
+      expect(spy).toHaveBeenCalledWith("/v1/indicators/cftc-positioning", {});
+      expect(result).toEqual(mock);
+    });
+  });
+
+  describe("congressionalTrades()", () => {
+    it("fetches congressional trades array", async () => {
+      const mock: CongressionalTradeIndicator[] = [
+        {
+          member: "Rep. Example",
+          ticker: "XOM",
+          transaction_type: "buy",
+          transaction_date: "2024-01-05",
+        },
+      ];
+
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue(mock);
+
+      const result = await client.indicators.congressionalTrades();
+
+      expect(spy).toHaveBeenCalledWith("/v1/indicators/congressional-trades", {});
+      expect(result).toEqual(mock);
+    });
+
+    it("unwraps { data } envelope", async () => {
+      const mock: CongressionalTradeIndicator[] = [
+        { ticker: "CVX", transaction_date: "2024-01-05" },
+      ];
+      vi.spyOn(client as any, "request").mockResolvedValue({ data: mock });
+
+      const result = await client.indicators.congressionalTrades();
+
+      expect(result).toEqual(mock);
+    });
+  });
+});

--- a/tests/resources/raw.test.ts
+++ b/tests/resources/raw.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { OilPriceAPI } from "../../src/client.js";
+
+/**
+ * Raw-response access tests (issue #7).
+ *
+ * Verifies that client.raw.* exposes the underlying HTTP status + headers
+ * alongside the parsed data, and that the parsed data matches the non-raw
+ * methods exactly.
+ */
+describe("RawResource", () => {
+  let client: OilPriceAPI;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    client = new OilPriceAPI({ apiKey: "test_key_123", retries: 0 });
+    fetchSpy = vi.spyOn(global, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: "OK",
+      headers: new Headers(headers),
+      text: async () => JSON.stringify(body),
+    } as Response;
+  }
+
+  describe("getLatestPrices()", () => {
+    it("returns data, status, and headers", async () => {
+      fetchSpy.mockResolvedValue(
+        mockResponse({ status: "success", data: { price: 75.5, commodity: "WTI_USD" } }, 200, {
+          "x-ratelimit-remaining": "99",
+        }),
+      );
+
+      const result = await client.raw.getLatestPrices({ commodity: "WTI_USD" });
+
+      expect(result.status).toBe(200);
+      expect(result.headers.get("x-ratelimit-remaining")).toBe("99");
+      // Same shape as client.getLatestPrices (single price wrapped in array)
+      expect(Array.isArray(result.data)).toBe(true);
+      expect(result.data[0]).toMatchObject({ price: 75.5 });
+    });
+
+    it("parsed data matches the non-raw method", async () => {
+      const body = { status: "success", data: { price: 80, commodity: "WTI_USD" } };
+
+      fetchSpy.mockResolvedValue(mockResponse(body));
+      const plain = await client.getLatestPrices();
+
+      fetchSpy.mockResolvedValue(mockResponse(body));
+      const raw = await client.raw.getLatestPrices();
+
+      expect(raw.data).toEqual(plain);
+    });
+
+    it("sends by_code query param when commodity provided", async () => {
+      fetchSpy.mockResolvedValue(mockResponse({ status: "success", data: { price: 1 } }));
+
+      await client.raw.getLatestPrices({ commodity: "BRENT_CRUDE_USD" });
+
+      const url = (fetchSpy.mock.calls[0][0] as string).toString();
+      expect(url).toContain("by_code=BRENT_CRUDE_USD");
+    });
+  });
+
+  describe("getHistoricalPrices()", () => {
+    it("returns historical prices array with status", async () => {
+      fetchSpy.mockResolvedValue(
+        mockResponse({
+          status: "success",
+          data: { prices: [{ price: 1 }, { price: 2 }] },
+        }),
+      );
+
+      const result = await client.raw.getHistoricalPrices({ period: "past_week" });
+
+      expect(result.status).toBe(200);
+      expect(result.data).toHaveLength(2);
+    });
+
+    it("forwards all filter params", async () => {
+      fetchSpy.mockResolvedValue(mockResponse({ status: "success", data: { prices: [] } }));
+
+      await client.raw.getHistoricalPrices({
+        commodity: "WTI_USD",
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
+        interval: "daily",
+        perPage: 50,
+        page: 2,
+      });
+
+      const url = (fetchSpy.mock.calls[0][0] as string).toString();
+      expect(url).toContain("by_code=WTI_USD");
+      expect(url).toContain("start_date=2024-01-01");
+      expect(url).toContain("end_date=2024-12-31");
+      expect(url).toContain("interval=daily");
+      expect(url).toContain("per_page=50");
+      expect(url).toContain("page=2");
+    });
+  });
+
+  describe("getCommodities()", () => {
+    it("returns commodities response with headers", async () => {
+      fetchSpy.mockResolvedValue(
+        mockResponse({ status: "success", data: { commodities: [{ code: "WTI_USD" }] } }, 200, {
+          "content-type": "application/json",
+        }),
+      );
+
+      const result = await client.raw.getCommodities();
+
+      expect(result.status).toBe(200);
+      expect(result.headers.get("content-type")).toBe("application/json");
+      expect(result.data).toMatchObject({ commodities: [{ code: "WTI_USD" }] });
+    });
+  });
+
+  describe("getCommodityCategories() / getCommodity()", () => {
+    it("getCommodityCategories() hits the categories endpoint", async () => {
+      fetchSpy.mockResolvedValue(
+        mockResponse({ status: "success", data: { oil: { name: "Oil" } } }),
+      );
+
+      const result = await client.raw.getCommodityCategories();
+
+      expect(result.status).toBe(200);
+      const url = (fetchSpy.mock.calls[0][0] as string).toString();
+      expect(url).toContain("/v1/commodities/categories");
+    });
+
+    it("getCommodity() hits the code endpoint", async () => {
+      fetchSpy.mockResolvedValue(
+        mockResponse({ status: "success", data: { code: "WTI_USD", name: "WTI" } }),
+      );
+
+      const result = await client.raw.getCommodity("WTI_USD");
+
+      expect(result.status).toBe(200);
+      expect(result.data).toMatchObject({ code: "WTI_USD" });
+      const url = (fetchSpy.mock.calls[0][0] as string).toString();
+      expect(url).toContain("/v1/commodities/WTI_USD");
+    });
+  });
+
+  describe("get() generic", () => {
+    it("makes an arbitrary GET and returns raw response", async () => {
+      fetchSpy.mockResolvedValue(
+        mockResponse({ status: "success", data: { contract: "CL.1", last: 70 } }, 201),
+      );
+
+      const result = await client.raw.get<{ contract: string; last: number }>("/v1/futures/CL.1");
+
+      expect(result.status).toBe(201);
+      expect(result.data).toEqual({ contract: "CL.1", last: 70 });
+      const url = (fetchSpy.mock.calls[0][0] as string).toString();
+      expect(url).toContain("/v1/futures/CL.1");
+    });
+  });
+
+  it("does not break the existing non-raw return shape", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ status: "success", data: { price: 99 } }));
+
+    const prices = await client.getLatestPrices();
+    // Still returns a plain array, not an APIResponse wrapper
+    expect(Array.isArray(prices)).toBe(true);
+    expect((prices as any).status).toBeUndefined();
+  });
+});

--- a/tests/resources/spreads.test.ts
+++ b/tests/resources/spreads.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { OilPriceAPI } from "../../src/client.js";
+import type { SpreadValue, HistoricalSpreadValue } from "../../src/resources/spreads.js";
+
+describe("SpreadsResource", () => {
+  let client: OilPriceAPI;
+
+  beforeEach(() => {
+    client = new OilPriceAPI({ apiKey: "test_key_123" });
+    vi.clearAllMocks();
+  });
+
+  describe("get()", () => {
+    it("fetches a spread by type", async () => {
+      const mock: SpreadValue = {
+        type: "crack",
+        name: "3:2:1 Crack",
+        value: 22.5,
+        unit: "USD/bbl",
+        timestamp: "2024-01-15T10:00:00Z",
+      };
+
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue(mock);
+
+      const result = await client.spreads.get("crack");
+
+      expect(spy).toHaveBeenCalledWith("/v1/spreads/crack", {});
+      expect(result).toEqual(mock);
+    });
+
+    it("throws on empty type", async () => {
+      await expect(client.spreads.get("" as any)).rejects.toThrow(
+        "Spread type must be a non-empty string",
+      );
+    });
+  });
+
+  describe("named helpers", () => {
+    it.each([
+      ["crack", "crack"],
+      ["basis", "basis"],
+      ["curveStructure", "curve-structure"],
+      ["margin", "margin"],
+      ["physicalPremium", "physical-premium"],
+    ])("%s() calls /v1/spreads/%s", async (method, slug) => {
+      const spy = vi
+        .spyOn(client as any, "request")
+        .mockResolvedValue({ type: slug, value: 1, timestamp: "t" });
+
+      await (client.spreads as any)[method]();
+
+      expect(spy).toHaveBeenCalledWith(`/v1/spreads/${slug}`, {});
+    });
+  });
+
+  describe("historical()", () => {
+    it("fetches historical with date filters", async () => {
+      const mock: HistoricalSpreadValue[] = [
+        { date: "2024-01-01", value: 20 },
+        { date: "2024-01-02", value: 21 },
+      ];
+
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue(mock);
+
+      const result = await client.spreads.historical("basis", {
+        startDate: "2024-01-01",
+        endDate: "2024-01-31",
+      });
+
+      expect(spy).toHaveBeenCalledWith("/v1/spreads/basis/historical", {
+        start_date: "2024-01-01",
+        end_date: "2024-01-31",
+      });
+      expect(result).toHaveLength(2);
+    });
+
+    it("unwraps { data } envelope", async () => {
+      const mock: HistoricalSpreadValue[] = [{ date: "2024-01-01", value: 1 }];
+      vi.spyOn(client as any, "request").mockResolvedValue({ data: mock });
+
+      const result = await client.spreads.historical("margin");
+
+      expect(result).toEqual(mock);
+    });
+  });
+
+  describe("all()", () => {
+    it("fetches all spreads for a type", async () => {
+      const mock: SpreadValue[] = [
+        { type: "crack", value: 22, timestamp: "t1" },
+        { type: "crack", value: 23, timestamp: "t2" },
+      ];
+
+      const spy = vi.spyOn(client as any, "request").mockResolvedValue(mock);
+
+      const result = await client.spreads.all("crack");
+
+      expect(spy).toHaveBeenCalledWith("/v1/spreads/crack/all", {});
+      expect(result).toHaveLength(2);
+    });
+
+    it("unwraps { data } envelope", async () => {
+      const mock: SpreadValue[] = [{ type: "basis", value: 1, timestamp: "t" }];
+      vi.spyOn(client as any, "request").mockResolvedValue({ data: mock });
+
+      const result = await client.spreads.all("basis");
+
+      expect(result).toEqual(mock);
+    });
+  });
+});


### PR DESCRIPTION
Brings the Node/TypeScript SDK to first-class REST parity (REST additions only; WebSocket/streaming is a separate effort and intentionally out of scope here).

## Additions

### 1. Raw-response access (issue #7) — #1 requested enhancement
- New `client.raw.*` accessor returning `{ data, status, headers }` (`APIResponse<T>`).
- `request()` was refactored to delegate to an internal `requestRaw()`; response-shaping logic was extracted into a shared `shapeResponseData()`. **Existing return shapes are unchanged.**
- Raw helpers: `getLatestPrices`, `getHistoricalPrices`, `getCommodities`, `getCommodityCategories`, `getCommodity`, plus a generic `raw.get<T>(endpoint, params?)`.

### 2. Typed ICE Brent / Gasoil futures helpers (issue #1)
- `FUTURES_CONTRACTS` constants (BRENT `BZ`, WTI `CL`, GASOIL `G`, NATURAL_GAS, TTF_GAS, LNG_JKM, EUA_CARBON, UK_CARBON) + `FUTURES_FAMILY_SLUGS`.
- `client.futures.family(slug)` and named helpers `brent()`, `wti()`, `gasoil()`, `naturalGas()`, `ttfGas()`, `lngJkm()`, `euaCarbon()`, `ukCarbon()`.
- Each family (`ice-brent|ice-gasoil|ice-wti|natural-gas|ttf-gas|lng-jkm|eua-carbon|uk-carbon`) exposes `latest`, `historical`, `ohlc`, `intraday`, `spreads`, `curve`, `spreadHistory`.

### 3. Spreads resource — `client.spreads.*`
- `/v1/spreads/{crack,basis,curve-structure,margin,physical-premium}` with `/historical` and `/all`.
- Named helpers + `get(type)`, `historical(type, opts)`, `all(type)`. New typed responses.

### 4. Indicators resource — `client.indicators.*`
- `/v1/indicators/{fuel-switching,price-context,storage-analytics,annotations,cftc-positioning,congressional-trades}` with typed responses + generic `get(type)`.

### 5. EI namespace tests
- Added solid mocked unit tests for the entire previously-untested `ei.*` namespace (rigCounts, oilInventories, opecProduction, drillingProductivity, forecasts, wellPermits, fracFocus, wellTimeline). Coverage for `src/resources/ei` went from ~0% to ~93%.

### Docs
- README updated with compiling examples for every new method (typed futures helpers, spreads, indicators, raw responses).

## Test / build results
- `npx tsc --noEmit`: clean
- `npm test`: **351 passed**, 1 skipped (25 files) — up from 281
- `npm run build`: success (ESM + CJS)
- `npm run lint`: 0 errors (11 pre-existing `no-explicit-any` warnings only)

Version intentionally **not** bumped and no tag created — release left to a human.

Closes #1, closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)