### PR TITLE
fix: correct analytics params (code1/code2) + param-correctness audit + live demo contract tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint src/",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:live": "vitest run --config vitest.live.config.ts",
     "docs": "typedoc",
     "prepublishOnly": "npm run build"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,8 @@ import type {
   CategoriesResponse,
   DataConnectorPrice,
   DataConnectorOptions,
+  DemoPricesResponse,
+  DemoCommoditiesResponse,
 } from "./types.js";
 import {
   OilPriceAPIError,
@@ -736,5 +738,91 @@ export class OilPriceAPI {
    */
   async getCommodity(code: string): Promise<Commodity> {
     return this.request<Commodity>(`/v1/commodities/${code}`, {});
+  }
+
+  /**
+   * Fetch live sample prices from the public, no-auth demo endpoint.
+   *
+   * Hits `GET /v1/demo/prices` (no API key required) and returns the parsed
+   * `{ prices, meta }` envelope. Useful for trying the client without
+   * credentials. Subject to the demo rate limit (~20 requests/hour).
+   *
+   * @example
+   * ```typescript
+   * const demo = await client.getDemoPrices();
+   * const brent = demo.prices.find(p => p.code === 'BRENT_CRUDE_USD');
+   * console.log(brent?.price);
+   * ```
+   */
+  async getDemoPrices(): Promise<DemoPricesResponse> {
+    return this.requestDemo<DemoPricesResponse>("/v1/demo/prices");
+  }
+
+  /**
+   * Fetch the catalogue of commodities from the public, no-auth demo endpoint.
+   *
+   * Hits `GET /v1/demo/commodities` (no API key required) and returns the parsed
+   * `{ commodities, meta }` envelope, where `meta.free_commodities` lists the
+   * codes available on the free demo tier.
+   *
+   * @example
+   * ```typescript
+   * const demo = await client.getDemoCommodities();
+   * console.log(demo.meta.total, demo.meta.free_commodities);
+   * ```
+   */
+  async getDemoCommodities(): Promise<DemoCommoditiesResponse> {
+    return this.requestDemo<DemoCommoditiesResponse>("/v1/demo/commodities");
+  }
+
+  /**
+   * Minimal fetch for the no-auth demo endpoints.
+   *
+   * Unlike {@link request}, this does NOT run the latest/historical response
+   * shaping (which would strip the `meta` block) and does NOT require an API
+   * key — it returns the raw `data` envelope from `{ status, data }`.
+   */
+  private async requestDemo<T>(endpoint: string): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+    this.log(`Demo request: ${url}`);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": buildUserAgent(),
+          "X-SDK-Name": SDK_NAME,
+          "X-SDK-Version": SDK_VERSION,
+        },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        let message = `HTTP ${response.status}: ${response.statusText}`;
+        try {
+          const json = JSON.parse(body);
+          message = json.message || json.error || message;
+        } catch {
+          // non-JSON error body
+        }
+        throw new OilPriceAPIError(message, response.status, "HTTP_ERROR");
+      }
+
+      const parsed: any = JSON.parse(await response.text());
+      // Demo envelope is { status: "success", data: { ... } }.
+      return (parsed.data !== undefined ? parsed.data : parsed) as T;
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new TimeoutError("Request timeout", this.timeout);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ export type {
   CategoriesResponse,
   DataConnectorPrice,
   DataConnectorOptions,
+  DemoPrice,
+  DemoPricesResponse,
+  DemoCommoditiesResponse,
 } from "./types.js";
 export type {
   DieselPrice,
@@ -102,9 +105,12 @@ export type {
   PerformanceOptions,
   StatisticalAnalysis,
   CorrelationAnalysis,
+  CorrelationOptions,
   TrendAnalysis,
+  TrendOptions,
   SpreadAnalysis,
-  ForecastPoint,
+  SpreadOptions,
+  ForecastOptions,
   PriceForecast as AnalyticsPriceForecast,
 } from "./resources/analytics.js";
 export type { MonthlyForecast, ForecastAccuracy, ArchivedForecast } from "./resources/forecasts.js";

--- a/src/resources/analytics.ts
+++ b/src/resources/analytics.ts
@@ -3,41 +3,40 @@
  *
  * Access advanced analytics including performance metrics, statistical analysis,
  * correlations, trend detection, spreads, and forecasts.
+ *
+ * NOTE ON PARAMETERS: The OilPriceAPI analytics controller reads commodity
+ * identifiers as `code` / `code1` / `code2` and the lookback window as `period`
+ * (in days). Earlier versions of this SDK sent `commodity` / `commodity1` /
+ * `commodity2` / `days`, which the API silently ignored (and `correlation`
+ * returned "code1 and code2 parameters are required"). These methods now send
+ * the parameter names the controller actually reads.
  */
 
 import type { OilPriceAPI } from "../client.js";
 import { ValidationError } from "../errors.js";
 
 /**
- * Performance metrics for commodities
+ * Performance metrics for the authenticated user's API usage.
+ *
+ * NOTE: `/v1/analytics/performance` returns the user's API usage analytics
+ * (request counts, error rate, endpoint breakdown) for a dashboard, NOT
+ * commodity price performance. It accepts a `range` of `7d` | `30d` | `90d`.
  */
 export interface PerformanceMetrics {
-  /** Commodity code */
-  commodity?: string;
-  /** Time period analyzed (in days) */
-  period_days: number;
-  /** Average price over period */
-  average_price: number;
-  /** Price volatility (standard deviation) */
-  volatility: number;
-  /** Percentage return over period */
-  return_percent: number;
-  /** Highest price in period */
-  high: number;
-  /** Lowest price in period */
-  low: number;
-  /** ISO timestamp */
-  timestamp: string;
+  overview?: Record<string, unknown>;
+  dailyUsage?: Array<Record<string, unknown>>;
+  hourlyDistribution?: Array<Record<string, unknown>>;
+  endpointBreakdown?: Array<Record<string, unknown>>;
+  geographicData?: Array<Record<string, unknown>>;
+  [key: string]: unknown;
 }
 
 /**
  * Options for performance query
  */
 export interface PerformanceOptions {
-  /** Commodity code to analyze */
-  commodity?: string;
-  /** Number of days to analyze (default: 30) */
-  days?: number;
+  /** Time range for usage analytics: '7d' | '30d' | '90d' (default: '30d') */
+  range?: "7d" | "30d" | "90d";
 }
 
 /**
@@ -45,111 +44,101 @@ export interface PerformanceOptions {
  */
 export interface StatisticalAnalysis {
   /** Commodity code */
-  commodity: string;
+  code: string;
   /** Time period analyzed (in days) */
-  period_days: number;
-  /** Mean price */
-  mean: number;
-  /** Median price */
-  median: number;
-  /** Standard deviation */
-  std_dev: number;
-  /** Variance */
-  variance: number;
-  /** Minimum price */
-  min: number;
-  /** Maximum price */
-  max: number;
-  /** 25th percentile */
-  percentile_25?: number;
-  /** 75th percentile */
-  percentile_75?: number;
-  /** Skewness */
-  skewness?: number;
-  /** Kurtosis */
-  kurtosis?: number;
-  /** ISO timestamp */
-  timestamp: string;
+  period: number;
+  /** Statistical metrics computed for the commodity */
+  statistics: Record<string, unknown>;
+  /** Tier of the requesting user */
+  tier?: string;
+  [key: string]: unknown;
 }
 
 /**
  * Correlation analysis between two commodities
  */
 export interface CorrelationAnalysis {
+  /** Response type: 'analysis' | 'rolling' | 'matrix' */
+  type?: string;
   /** First commodity code */
-  commodity1: string;
+  code1?: string;
   /** Second commodity code */
-  commodity2: string;
+  code2?: string;
   /** Time period analyzed (in days) */
-  period_days: number;
+  period?: number;
   /** Pearson correlation coefficient (-1 to 1) */
-  correlation: number;
+  correlation?: number;
   /** Correlation strength description */
-  strength?: "strong" | "moderate" | "weak" | "none";
-  /** R-squared value */
-  r_squared?: number;
-  /** ISO timestamp */
-  timestamp: string;
+  strength?: string;
+  /** Tier of the requesting user */
+  tier?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Options for correlation query
+ */
+export interface CorrelationOptions {
+  /** Lookback window in days (default: 30) */
+  period?: number;
+  /** Correlation variant: 'analysis' (default), 'rolling', or 'matrix' */
+  type?: "analysis" | "rolling" | "matrix";
+  /** Rolling window size in days (only used when type === 'rolling') */
+  window?: number;
+  /** Comma-separated codes for a correlation matrix (only when type === 'matrix') */
+  codes?: string[];
 }
 
 /**
  * Trend analysis results
  */
 export interface TrendAnalysis {
+  /** Response type: 'analysis' | 'sma' | 'ema' | 'rsi' | 'levels' */
+  type?: string;
   /** Commodity code */
-  commodity: string;
+  code?: string;
   /** Time period analyzed (in days) */
-  period_days: number;
-  /** Overall trend direction */
-  trend: "upward" | "downward" | "sideways";
-  /** Trend strength (0-100) */
-  strength: number;
-  /** Slope of trend line */
-  slope?: number;
-  /** Price momentum */
-  momentum?: number;
-  /** Support level */
-  support?: number;
-  /** Resistance level */
-  resistance?: number;
-  /** ISO timestamp */
-  timestamp: string;
+  period?: number;
+  /** Tier of the requesting user */
+  tier?: string;
+  [key: string]: unknown;
 }
 
 /**
- * Spread analysis between commodities
+ * Options for trend query
+ */
+export interface TrendOptions {
+  /** Lookback window in days (default: 30) */
+  period?: number;
+  /** Trend variant: 'analysis' (default), 'sma', 'ema', 'rsi', or 'levels' */
+  type?: "analysis" | "sma" | "ema" | "rsi" | "levels";
+  /** Moving-average / indicator window (used by sma/ema/rsi) */
+  window?: number;
+}
+
+/**
+ * Spread analysis for a named commodity spread (e.g. 'wti_brent')
  */
 export interface SpreadAnalysis {
-  /** First commodity code */
-  commodity1: string;
-  /** Second commodity code */
-  commodity2: string;
-  /** Current spread (commodity1 - commodity2) */
-  spread: number;
-  /** Historical average spread */
-  average_spread?: number;
-  /** Spread standard deviation */
-  spread_volatility?: number;
-  /** Z-score of current spread */
-  z_score?: number;
-  /** ISO timestamp */
-  timestamp: string;
+  /** Response type: 'current' | 'historical' */
+  type?: string;
+  /** The named spread analyzed */
+  spread?: string;
+  /** Time period analyzed (in days) */
+  period?: number;
+  /** Tier of the requesting user */
+  tier?: string;
+  [key: string]: unknown;
 }
 
 /**
- * Forecast data point
+ * Options for spread query
  */
-export interface ForecastPoint {
-  /** Forecast date */
-  date: string;
-  /** Forecasted price */
-  price: number;
-  /** Lower bound of confidence interval */
-  lower_bound?: number;
-  /** Upper bound of confidence interval */
-  upper_bound?: number;
-  /** Confidence level (e.g., 0.95 for 95%) */
-  confidence?: number;
+export interface SpreadOptions {
+  /** Lookback window in days (default: 30) */
+  period?: number;
+  /** Spread variant: 'current' (default) or 'historical' */
+  type?: "current" | "historical";
 }
 
 /**
@@ -157,22 +146,22 @@ export interface ForecastPoint {
  */
 export interface PriceForecast {
   /** Commodity code */
-  commodity: string;
-  /** Forecast model used */
-  model?: string;
-  /** Forecast horizon (days ahead) */
-  horizon_days: number;
-  /** Array of forecast points */
-  forecast: ForecastPoint[];
-  /** Model accuracy metrics */
-  accuracy?: {
-    /** Mean Absolute Percentage Error */
-    mape?: number;
-    /** Root Mean Squared Error */
-    rmse?: number;
-  };
-  /** ISO timestamp when forecast was generated */
-  timestamp: string;
+  code?: string;
+  /** Forecast method used */
+  method?: string;
+  /** Tier of the requesting user */
+  tier?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Options for forecast query
+ */
+export interface ForecastOptions {
+  /** Forecast method (default: 'ema') */
+  method?: string;
+  /** Lookback window in days (default: 90) */
+  period?: number;
 }
 
 /**
@@ -187,13 +176,8 @@ export interface PriceForecast {
  *
  * const client = new OilPriceAPI({ apiKey: 'your_key' });
  *
- * // Get performance metrics
- * const perf = await client.analytics.performance({ commodity: 'WTI_USD', days: 30 });
- * console.log(`30-day return: ${perf.return_percent}%`);
- * console.log(`Volatility: ${perf.volatility}`);
- *
- * // Analyze correlation
- * const corr = await client.analytics.correlation('WTI_USD', 'BRENT_CRUDE_USD', 90);
+ * // Analyze correlation between two commodities (90-day window)
+ * const corr = await client.analytics.correlation('WTI_USD', 'BRENT_CRUDE_USD', { period: 90 });
  * console.log(`Correlation: ${corr.correlation}`);
  * ```
  */
@@ -201,219 +185,158 @@ export class AnalyticsResource {
   constructor(private client: OilPriceAPI) {}
 
   /**
-   * Get performance metrics for a commodity
+   * Get the authenticated user's API usage analytics for the dashboard.
    *
-   * Returns key performance indicators including returns, volatility,
-   * and price range over a specified period.
+   * Maps to `GET /v1/analytics/performance`, which reads a `range`
+   * parameter (`7d` | `30d` | `90d`).
    *
-   * @param options - Analysis parameters
-   * @returns Performance metrics
-   *
-   * @throws {OilPriceAPIError} If API request fails
-   *
-   * @example
-   * ```typescript
-   * const metrics = await client.analytics.performance({
-   *   commodity: 'WTI_USD',
-   *   days: 30
-   * });
-   * console.log(`Return: ${metrics.return_percent}%`);
-   * console.log(`Volatility: ${metrics.volatility}`);
-   * console.log(`High: $${metrics.high}, Low: $${metrics.low}`);
-   * ```
+   * @param options - `{ range }` (default range '30d')
+   * @returns Usage analytics (overview, daily usage, endpoint breakdown, ...)
    */
   async performance(options?: PerformanceOptions): Promise<PerformanceMetrics> {
     const params: Record<string, string> = {};
-    if (options?.commodity) params.commodity = options.commodity;
-    if (options?.days) params.days = options.days.toString();
+    if (options?.range) params.range = options.range;
 
-    return this.client["request"]<PerformanceMetrics>(
-      "/v1/analytics/performance",
-      params,
-    );
+    return this.client["request"]<PerformanceMetrics>("/v1/analytics/performance", params);
   }
 
   /**
-   * Get statistical analysis for a commodity
+   * Get statistical analysis for a commodity.
    *
-   * Returns comprehensive statistical metrics including mean, median,
-   * standard deviation, and distribution characteristics.
+   * Maps to `GET /v1/analytics/statistics`, which reads `code` and `period`.
    *
-   * @param commodity - Commodity code to analyze
-   * @param days - Number of days to analyze (default: 30)
+   * @param code - Commodity code to analyze (e.g. 'WTI_USD')
+   * @param period - Lookback window in days (default: 30)
    * @returns Statistical analysis
    *
-   * @throws {NotFoundError} If commodity not found
-   * @throws {OilPriceAPIError} If API request fails
-   *
-   * @example
-   * ```typescript
-   * const stats = await client.analytics.statistics('BRENT_CRUDE_USD', 90);
-   * console.log(`Mean: $${stats.mean}`);
-   * console.log(`Std Dev: ${stats.std_dev}`);
-   * console.log(`Range: $${stats.min} - $${stats.max}`);
-   * ```
+   * @throws {ValidationError} If code is empty
    */
-  async statistics(
-    commodity: string,
-    days?: number,
-  ): Promise<StatisticalAnalysis> {
-    if (!commodity || typeof commodity !== "string") {
+  async statistics(code: string, period?: number): Promise<StatisticalAnalysis> {
+    if (!code || typeof code !== "string") {
       throw new ValidationError("Commodity code must be a non-empty string");
     }
 
-    const params: Record<string, string> = { commodity };
-    if (days) params.days = days.toString();
+    const params: Record<string, string> = { code };
+    if (period !== undefined) params.period = period.toString();
 
-    return this.client["request"]<StatisticalAnalysis>(
-      "/v1/analytics/statistics",
-      params,
-    );
+    return this.client["request"]<StatisticalAnalysis>("/v1/analytics/statistics", params);
   }
 
   /**
-   * Analyze correlation between two commodities
+   * Analyze correlation between two commodities.
    *
-   * Calculates the Pearson correlation coefficient to measure how closely
-   * two commodities move together.
+   * Maps to `GET /v1/analytics/correlation`, which reads `code1`, `code2`,
+   * `period` and optional `type`, `window`, `codes`.
    *
-   * @param commodity1 - First commodity code
-   * @param commodity2 - Second commodity code
-   * @param days - Number of days to analyze (default: 30)
+   * @param code1 - First commodity code
+   * @param code2 - Second commodity code
+   * @param options - Lookback window in days, or `{ period, type, window, codes }`
    * @returns Correlation analysis
    *
-   * @throws {NotFoundError} If either commodity not found
-   * @throws {OilPriceAPIError} If API request fails
+   * @throws {ValidationError} If either code is empty
    *
    * @example
    * ```typescript
-   * const corr = await client.analytics.correlation('WTI_USD', 'BRENT_CRUDE_USD', 90);
-   * console.log(`Correlation: ${corr.correlation}`);
-   * console.log(`Strength: ${corr.strength}`);
-   * console.log(`R-squared: ${corr.r_squared}`);
+   * const corr = await client.analytics.correlation('WTI_USD', 'BRENT_CRUDE_USD', { period: 90 });
+   * console.log(corr.correlation);
    * ```
    */
   async correlation(
-    commodity1: string,
-    commodity2: string,
-    days?: number,
+    code1: string,
+    code2: string,
+    options?: number | CorrelationOptions,
   ): Promise<CorrelationAnalysis> {
-    if (!commodity1 || typeof commodity1 !== "string") {
+    if (!code1 || typeof code1 !== "string") {
       throw new ValidationError("First commodity code must be a non-empty string");
     }
-    if (!commodity2 || typeof commodity2 !== "string") {
+    if (!code2 || typeof code2 !== "string") {
       throw new ValidationError("Second commodity code must be a non-empty string");
     }
 
-    const params: Record<string, string> = {
-      commodity1,
-      commodity2,
-    };
-    if (days) params.days = days.toString();
+    const opts: CorrelationOptions =
+      typeof options === "number" ? { period: options } : options || {};
 
-    return this.client["request"]<CorrelationAnalysis>(
-      "/v1/analytics/correlation",
-      params,
-    );
+    const params: Record<string, string> = { code1, code2 };
+    if (opts.period !== undefined) params.period = opts.period.toString();
+    if (opts.type) params.type = opts.type;
+    if (opts.window !== undefined) params.window = opts.window.toString();
+    if (opts.codes && opts.codes.length > 0) params.codes = opts.codes.join(",");
+
+    return this.client["request"]<CorrelationAnalysis>("/v1/analytics/correlation", params);
   }
 
   /**
-   * Analyze price trend for a commodity
+   * Analyze price trend for a commodity.
    *
-   * Detects trend direction, strength, and key levels (support/resistance).
+   * Maps to `GET /v1/analytics/trend`, which reads `code`, `period` and
+   * optional `type` ('analysis' | 'sma' | 'ema' | 'rsi' | 'levels') and `window`.
    *
-   * @param commodity - Commodity code to analyze
-   * @param days - Number of days to analyze (default: 30)
+   * @param code - Commodity code to analyze
+   * @param options - Lookback window in days, or `{ period, type, window }`
    * @returns Trend analysis
    *
-   * @throws {NotFoundError} If commodity not found
-   * @throws {OilPriceAPIError} If API request fails
-   *
-   * @example
-   * ```typescript
-   * const trend = await client.analytics.trend('WTI_USD', 60);
-   * console.log(`Trend: ${trend.trend} (strength: ${trend.strength})`);
-   * console.log(`Support: $${trend.support}`);
-   * console.log(`Resistance: $${trend.resistance}`);
-   * ```
+   * @throws {ValidationError} If code is empty
    */
-  async trend(commodity: string, days?: number): Promise<TrendAnalysis> {
-    if (!commodity || typeof commodity !== "string") {
+  async trend(code: string, options?: number | TrendOptions): Promise<TrendAnalysis> {
+    if (!code || typeof code !== "string") {
       throw new ValidationError("Commodity code must be a non-empty string");
     }
 
-    const params: Record<string, string> = { commodity };
-    if (days) params.days = days.toString();
+    const opts: TrendOptions = typeof options === "number" ? { period: options } : options || {};
+
+    const params: Record<string, string> = { code };
+    if (opts.period !== undefined) params.period = opts.period.toString();
+    if (opts.type) params.type = opts.type;
+    if (opts.window !== undefined) params.window = opts.window.toString();
 
     return this.client["request"]<TrendAnalysis>("/v1/analytics/trend", params);
   }
 
   /**
-   * Analyze spread between two commodities
+   * Analyze a named commodity spread (basis / crack / ratio).
    *
-   * Calculates current spread and compares to historical patterns.
+   * Maps to `GET /v1/analytics/spread`, which reads `spread` (the named spread,
+   * e.g. 'wti_brent'), `period` and optional `type` ('current' | 'historical').
+   * Call with no `spread` to list the available named spreads.
    *
-   * @param commodity1 - First commodity code
-   * @param commodity2 - Second commodity code
-   * @returns Spread analysis
-   *
-   * @throws {NotFoundError} If either commodity not found
-   * @throws {OilPriceAPIError} If API request fails
+   * @param spread - Named spread (e.g. 'wti_brent'); omit to list available spreads
+   * @param options - Lookback window in days, or `{ period, type }`
+   * @returns Spread analysis (or the list of available spreads)
    *
    * @example
    * ```typescript
-   * const spread = await client.analytics.spread('BRENT_CRUDE_USD', 'WTI_USD');
-   * console.log(`Current spread: $${spread.spread}`);
-   * console.log(`Average spread: $${spread.average_spread}`);
-   * console.log(`Z-score: ${spread.z_score}`);
+   * const spread = await client.analytics.spread('wti_brent', { period: 30 });
+   * console.log(spread.current_spread);
    * ```
    */
-  async spread(
-    commodity1: string,
-    commodity2: string,
-  ): Promise<SpreadAnalysis> {
-    if (!commodity1 || typeof commodity1 !== "string") {
-      throw new ValidationError("First commodity code must be a non-empty string");
-    }
-    if (!commodity2 || typeof commodity2 !== "string") {
-      throw new ValidationError("Second commodity code must be a non-empty string");
-    }
+  async spread(spread?: string, options?: number | SpreadOptions): Promise<SpreadAnalysis> {
+    const opts: SpreadOptions = typeof options === "number" ? { period: options } : options || {};
 
-    return this.client["request"]<SpreadAnalysis>("/v1/analytics/spread", {
-      commodity1,
-      commodity2,
-    });
+    const params: Record<string, string> = {};
+    if (spread) params.spread = spread;
+    if (opts.period !== undefined) params.period = opts.period.toString();
+    if (opts.type) params.type = opts.type;
+
+    return this.client["request"]<SpreadAnalysis>("/v1/analytics/spread", params);
   }
 
   /**
-   * Get price forecast for a commodity
+   * Get a statistical price forecast for a commodity.
    *
-   * Returns forecasted prices with confidence intervals.
+   * Maps to `GET /v1/analytics/forecast`, which reads `code`, `method`
+   * (default 'ema') and `period` (default 90). Call with no `code` to list
+   * the available forecast methods.
    *
-   * @param commodity - Commodity code to forecast
-   * @returns Price forecast
-   *
-   * @throws {NotFoundError} If commodity not found
-   * @throws {OilPriceAPIError} If API request fails
-   *
-   * @example
-   * ```typescript
-   * const forecast = await client.analytics.forecast('WTI_USD');
-   * console.log(`Forecast model: ${forecast.model}`);
-   * console.log(`Horizon: ${forecast.horizon_days} days`);
-   *
-   * forecast.forecast.forEach(point => {
-   *   console.log(`${point.date}: $${point.price} (${point.lower_bound}-${point.upper_bound})`);
-   * });
-   * ```
+   * @param code - Commodity code to forecast; omit to list available methods
+   * @param options - `{ method, period }`
+   * @returns Price forecast (or the list of available methods)
    */
-  async forecast(commodity: string): Promise<PriceForecast> {
-    if (!commodity || typeof commodity !== "string") {
-      throw new ValidationError("Commodity code must be a non-empty string");
-    }
+  async forecast(code?: string, options?: ForecastOptions): Promise<PriceForecast> {
+    const params: Record<string, string> = {};
+    if (code) params.code = code;
+    if (options?.method) params.method = options.method;
+    if (options?.period !== undefined) params.period = options.period.toString();
 
-    return this.client["request"]<PriceForecast>("/v1/analytics/forecast", {
-      commodity,
-    });
+    return this.client["request"]<PriceForecast>("/v1/analytics/forecast", params);
   }
 }

--- a/src/resources/bunker-fuels.ts
+++ b/src/resources/bunker-fuels.ts
@@ -123,13 +123,30 @@ export interface HistoricalBunkerPrice {
 }
 
 /**
- * Options for historical bunker fuel query
+ * Options for historical bunker fuel query.
+ *
+ * The controller reads `from` / `to` (dates) and `interval` — not `start_date` /
+ * `end_date` / `fuel_type`. History is returned per port (all grades).
  */
 export interface HistoricalBunkerOptions {
   /** Start date in ISO 8601 format (YYYY-MM-DD) */
   startDate?: string;
   /** End date in ISO 8601 format (YYYY-MM-DD) */
   endDate?: string;
+  /** Aggregation interval (e.g. 'daily') */
+  interval?: string;
+}
+
+/**
+ * Options for port-to-port bunker spread query.
+ */
+export interface BunkerSpreadOptions {
+  /** Origin port code */
+  from: string;
+  /** Destination port code */
+  to: string;
+  /** Fuel grade (e.g. 'VLSFO') */
+  grade?: string;
 }
 
 /**
@@ -177,9 +194,10 @@ export class BunkerFuelsResource {
    * ```
    */
   async all(): Promise<BunkerFuelPrice[]> {
+    // Route is GET /v1/bunker-fuels/all (the bare /v1/bunker-fuels has no route).
     const response = await this.client["request"]<
       BunkerFuelPrice[] | { prices: BunkerFuelPrice[] }
-    >("/v1/bunker-fuels", {});
+    >("/v1/bunker-fuels/all", {});
 
     return Array.isArray(response) ? response : response.prices;
   }
@@ -206,10 +224,7 @@ export class BunkerFuelsResource {
       throw new ValidationError("Port code must be a non-empty string");
     }
 
-    return this.client["request"]<PortBunkerPrices>(
-      `/v1/bunker-fuels/ports/${code}`,
-      {},
-    );
+    return this.client["request"]<PortBunkerPrices>(`/v1/bunker-fuels/ports/${code}`, {});
   }
 
   /**
@@ -235,36 +250,40 @@ export class BunkerFuelsResource {
       throw new ValidationError("Ports must be a non-empty array of port codes");
     }
 
-    return this.client["request"]<PortPriceComparison>(
-      "/v1/bunker-fuels/compare",
-      {
-        ports: ports.join(","),
-      },
-    );
+    return this.client["request"]<PortPriceComparison>("/v1/bunker-fuels/compare", {
+      ports: ports.join(","),
+    });
   }
 
   /**
-   * Get bunker fuel price spreads
+   * Get the bunker fuel price spread between two ports.
    *
-   * Returns spreads between different fuel grades (e.g., VLSFO-IFO380).
+   * Maps to `GET /v1/bunker-fuels/spreads/ports`, which reads `from`, `to`
+   * and `grade`. (Earlier SDKs called `/v1/bunker-fuels/spreads` with no params,
+   * which 404'd.)
    *
-   * @returns Fuel price spreads
+   * @param options - `{ from, to, grade? }`
+   * @returns Port-to-port fuel price spread
    *
-   * @throws {OilPriceAPIError} If API request fails
+   * @throws {ValidationError} If from/to are missing
    *
    * @example
    * ```typescript
-   * const spreads = await client.bunkerFuels.spreads();
-   * spreads.spreads.forEach(spread => {
-   *   console.log(`${spread.fuel1}-${spread.fuel2} spread: $${spread.average_spread}`);
-   * });
+   * const spread = await client.bunkerFuels.spreads({ from: 'SIN', to: 'RTM', grade: 'VLSFO' });
    * ```
    */
-  async spreads(): Promise<BunkerFuelSpreads> {
-    return this.client["request"]<BunkerFuelSpreads>(
-      "/v1/bunker-fuels/spreads",
-      {},
-    );
+  async spreads(options: BunkerSpreadOptions): Promise<BunkerFuelSpreads> {
+    if (!options?.from || !options?.to) {
+      throw new ValidationError("Both 'from' and 'to' port codes are required");
+    }
+
+    const params: Record<string, string> = {
+      from: options.from,
+      to: options.to,
+    };
+    if (options.grade) params.grade = options.grade;
+
+    return this.client["request"]<BunkerFuelSpreads>("/v1/bunker-fuels/spreads/ports", params);
   }
 
   /**
@@ -278,9 +297,16 @@ export class BunkerFuelsResource {
    * @throws {NotFoundError} If port or fuel type not found
    * @throws {OilPriceAPIError} If API request fails
    *
+   * The history endpoint is keyed by port in the PATH (`/historical/:port_code`)
+   * and returns all grades for that port; it does not filter by a single fuel
+   * type. It reads `from` / `to` / `interval` query params.
+   *
+   * @param port - Port code (e.g., "SIN", "RTM") — used as a path segment
+   * @param options - `{ startDate, endDate, interval }`
+   *
    * @example
    * ```typescript
-   * const history = await client.bunkerFuels.historical('SIN', 'VLSFO', {
+   * const history = await client.bunkerFuels.historical('SIN', {
    *   startDate: '2024-01-01',
    *   endDate: '2024-12-31'
    * });
@@ -292,26 +318,21 @@ export class BunkerFuelsResource {
    */
   async historical(
     port: string,
-    fuelType: string,
     options?: HistoricalBunkerOptions,
   ): Promise<HistoricalBunkerPrice[]> {
     if (!port || typeof port !== "string") {
       throw new ValidationError("Port code must be a non-empty string");
     }
-    if (!fuelType || typeof fuelType !== "string") {
-      throw new ValidationError("Fuel type must be a non-empty string");
-    }
 
-    const params: Record<string, string> = {
-      port,
-      fuel_type: fuelType,
-    };
-    if (options?.startDate) params.start_date = options.startDate;
-    if (options?.endDate) params.end_date = options.endDate;
+    const params: Record<string, string> = {};
+    if (options?.startDate) params.from = options.startDate;
+    if (options?.endDate) params.to = options.endDate;
+    if (options?.interval) params.interval = options.interval;
 
+    // Port code is a PATH segment: GET /v1/bunker-fuels/historical/:port_code
     const response = await this.client["request"]<
       HistoricalBunkerPrice[] | { data: HistoricalBunkerPrice[] }
-    >("/v1/bunker-fuels/historical", params);
+    >(`/v1/bunker-fuels/historical/${port}`, params);
 
     return Array.isArray(response) ? response : response.data;
   }

--- a/src/resources/data-sources.ts
+++ b/src/resources/data-sources.ts
@@ -10,13 +10,7 @@ import { ValidationError } from "../errors.js";
 /**
  * Data source types
  */
-export type DataSourceType =
-  | "api"
-  | "database"
-  | "file"
-  | "sftp"
-  | "webhook"
-  | "custom";
+export type DataSourceType = "api" | "database" | "file" | "sftp" | "webhook" | "custom";
 
 /**
  * Data source status
@@ -25,6 +19,10 @@ export type DataSourceStatus = "active" | "paused" | "error" | "pending";
 
 /**
  * Data source configuration
+ *
+ * NOTE: The API reads `source_type`, `scraper_config`, `status` and `credentials`
+ * (nested under `data_source`). Earlier SDK versions used `type`/`config`/`enabled`,
+ * which the controller silently dropped.
  */
 export interface DataSource {
   /** Unique data source identifier */
@@ -32,27 +30,21 @@ export interface DataSource {
   /** User-friendly name */
   name: string;
   /** Data source type */
-  type: DataSourceType;
-  /** Connection configuration (encrypted) */
-  config: Record<string, unknown>;
-  /** Whether the data source is active */
-  enabled: boolean;
+  source_type: DataSourceType;
+  /** Scraper / connection configuration */
+  scraper_config?: Record<string, unknown>;
   /** Current status */
   status: DataSourceStatus;
   /** Last successful sync timestamp */
   last_sync_at?: string;
   /** Next scheduled sync timestamp */
   next_sync_at?: string;
-  /** Sync frequency in minutes */
-  sync_frequency_minutes?: number;
   /** Number of successful syncs */
-  successful_syncs: number;
+  successful_syncs?: number;
   /** Number of failed syncs */
-  failed_syncs: number;
+  failed_syncs?: number;
   /** Last error message */
   last_error?: string;
-  /** Optional metadata */
-  metadata?: Record<string, unknown>;
   /** ISO timestamp when source was created */
   created_at: string;
   /** ISO timestamp when source was last updated */
@@ -60,37 +52,39 @@ export interface DataSource {
 }
 
 /**
- * Parameters for creating a data source
+ * Parameters for creating a data source.
+ *
+ * Maps to the controller's `data_source_params` strong params:
+ * `source_type`, `name`, `status`, `credentials`, `scraper_config`.
  */
 export interface CreateDataSourceParams {
   /** User-friendly name */
   name: string;
   /** Data source type */
-  type: DataSourceType;
-  /** Connection configuration */
-  config: Record<string, unknown>;
-  /** Whether to enable immediately (default: true) */
-  enabled?: boolean;
-  /** Sync frequency in minutes (default: 60) */
-  sync_frequency_minutes?: number;
-  /** Optional metadata */
-  metadata?: Record<string, unknown>;
+  source_type: DataSourceType;
+  /** Scraper / connection configuration */
+  scraper_config?: Record<string, unknown>;
+  /** Credentials (encrypted server-side) */
+  credentials?: Record<string, unknown>;
+  /** Lifecycle status */
+  status?: DataSourceStatus;
 }
 
 /**
- * Parameters for updating a data source
+ * Parameters for updating a data source.
+ *
+ * Maps to `data_source_update_params`: `name`, `status`, `credentials`,
+ * `scraper_config` (source_type cannot be changed).
  */
 export interface UpdateDataSourceParams {
   /** User-friendly name */
   name?: string;
-  /** Connection configuration */
-  config?: Record<string, unknown>;
-  /** Whether the data source is active */
-  enabled?: boolean;
-  /** Sync frequency in minutes */
-  sync_frequency_minutes?: number;
-  /** Metadata */
-  metadata?: Record<string, unknown>;
+  /** Scraper / connection configuration */
+  scraper_config?: Record<string, unknown>;
+  /** Credentials (encrypted server-side) */
+  credentials?: Record<string, unknown>;
+  /** Lifecycle status */
+  status?: DataSourceStatus;
 }
 
 /**
@@ -224,9 +218,10 @@ export class DataSourcesResource {
    * ```
    */
   async list(): Promise<DataSource[]> {
-    const response = await this.client["request"]<
-      DataSource[] | { data_sources: DataSource[] }
-    >("/v1/data-sources", {});
+    const response = await this.client["request"]<DataSource[] | { data_sources: DataSource[] }>(
+      "/v1/data-sources",
+      {},
+    );
 
     return Array.isArray(response) ? response : response.data_sources;
   }
@@ -252,9 +247,10 @@ export class DataSourcesResource {
       throw new ValidationError("Data source ID must be a non-empty string");
     }
 
-    const response = await this.client["request"]<
-      DataSource | { data_source: DataSource }
-    >(`/v1/data-sources/${id}`, {});
+    const response = await this.client["request"]<DataSource | { data_source: DataSource }>(
+      `/v1/data-sources/${id}`,
+      {},
+    );
 
     return "data_source" in response ? response.data_source : response;
   }
@@ -287,16 +283,11 @@ export class DataSourcesResource {
     if (!params.name || typeof params.name !== "string") {
       throw new ValidationError("Data source name is required");
     }
-    if (!params.type) {
-      throw new ValidationError("Data source type is required");
-    }
-    if (!params.config || typeof params.config !== "object") {
-      throw new ValidationError("Data source config is required");
+    if (!params.source_type) {
+      throw new ValidationError("Data source source_type is required");
     }
 
-    const response = await this.client["request"]<
-      DataSource | { data_source: DataSource }
-    >(
+    const response = await this.client["request"]<DataSource | { data_source: DataSource }>(
       "/v1/data-sources",
       {},
       {
@@ -304,11 +295,10 @@ export class DataSourcesResource {
         body: {
           data_source: {
             name: params.name,
-            type: params.type,
-            config: params.config,
-            enabled: params.enabled ?? true,
-            sync_frequency_minutes: params.sync_frequency_minutes ?? 60,
-            metadata: params.metadata,
+            source_type: params.source_type,
+            status: params.status,
+            credentials: params.credentials,
+            scraper_config: params.scraper_config,
           },
         },
       },
@@ -338,17 +328,12 @@ export class DataSourcesResource {
    * });
    * ```
    */
-  async update(
-    id: string,
-    params: UpdateDataSourceParams,
-  ): Promise<DataSource> {
+  async update(id: string, params: UpdateDataSourceParams): Promise<DataSource> {
     if (!id || typeof id !== "string") {
       throw new ValidationError("Data source ID must be a non-empty string");
     }
 
-    const response = await this.client["request"]<
-      DataSource | { data_source: DataSource }
-    >(
+    const response = await this.client["request"]<DataSource | { data_source: DataSource }>(
       `/v1/data-sources/${id}`,
       {},
       {
@@ -379,11 +364,7 @@ export class DataSourcesResource {
       throw new ValidationError("Data source ID must be a non-empty string");
     }
 
-    await this.client["request"](
-      `/v1/data-sources/${id}`,
-      {},
-      { method: "DELETE" },
-    );
+    await this.client["request"](`/v1/data-sources/${id}`, {}, { method: "DELETE" });
   }
 
   /**
@@ -442,9 +423,10 @@ export class DataSourcesResource {
       throw new ValidationError("Data source ID must be a non-empty string");
     }
 
-    const response = await this.client["request"]<
-      DataSourceLog[] | { logs: DataSourceLog[] }
-    >(`/v1/data-sources/${id}/logs`, {});
+    const response = await this.client["request"]<DataSourceLog[] | { logs: DataSourceLog[] }>(
+      `/v1/data-sources/${id}/logs`,
+      {},
+    );
 
     return Array.isArray(response) ? response : response.logs;
   }
@@ -471,10 +453,7 @@ export class DataSourcesResource {
       throw new ValidationError("Data source ID must be a non-empty string");
     }
 
-    return this.client["request"]<DataSourceHealth>(
-      `/v1/data-sources/${id}/health`,
-      {},
-    );
+    return this.client["request"]<DataSourceHealth>(`/v1/data-sources/${id}/health`, {});
   }
 
   /**
@@ -494,15 +473,23 @@ export class DataSourcesResource {
    * console.log(`Credential rotation: ${result.success ? 'success' : 'failed'}`);
    * ```
    */
-  async rotateCredentials(id: string): Promise<CredentialRotationResponse> {
+  async rotateCredentials(
+    id: string,
+    credentials: Record<string, unknown>,
+  ): Promise<CredentialRotationResponse> {
     if (!id || typeof id !== "string") {
       throw new ValidationError("Data source ID must be a non-empty string");
     }
+    if (!credentials || typeof credentials !== "object") {
+      throw new ValidationError("New credentials object is required");
+    }
 
+    // Route is POST /v1/data-sources/:id/rotate_credentials (underscore) and
+    // the controller does params.require(:credentials).
     return this.client["request"]<CredentialRotationResponse>(
-      `/v1/data-sources/${id}/rotate-credentials`,
+      `/v1/data-sources/${id}/rotate_credentials`,
       {},
-      { method: "POST" },
+      { method: "POST", body: { credentials } },
     );
   }
 }

--- a/src/resources/ei/frac-focus.ts
+++ b/src/resources/ei/frac-focus.ts
@@ -109,18 +109,32 @@ export interface WellChemical {
 }
 
 /**
- * FracFocus search query
+ * FracFocus search query.
+ *
+ * Maps to the parameters the `search` action actually reads. Note: `operator`
+ * and `chemical` are NOT search params (use the dedicated by-operator /
+ * by-chemical endpoints); state filtering uses `states` (comma-separated, plural).
  */
 export interface FracFocusSearchQuery {
-  /** State filter */
-  state?: string;
-  /** Operator filter */
-  operator?: string;
-  /** Chemical filter */
-  chemical?: string;
-  /** Start date */
+  /** Comma-separated state codes (e.g. 'TX,NM') */
+  states?: string;
+  /** County name (partial match) */
+  county?: string;
+  /** Well name (partial match) */
+  well_name?: string;
+  /** API well number (partial match) */
+  api_number?: string;
+  /** Minimum total base water volume (gallons) */
+  min_water_gallons?: number;
+  /** Latitude for radius search */
+  latitude?: number;
+  /** Longitude for radius search */
+  longitude?: number;
+  /** Radius in miles (1-100, default 10) for lat/lng search */
+  radius_miles?: number;
+  /** Start date (job_start_date >=) */
   start_date?: string;
-  /** End date */
+  /** End date (job_start_date <=) */
   end_date?: string;
 }
 
@@ -161,9 +175,10 @@ export class EIFracFocusResource {
    * @returns Array of disclosure records
    */
   async list(): Promise<FracFocusRecord[]> {
-    const response = await this.client["request"]<
-      FracFocusRecord[] | { data: FracFocusRecord[] }
-    >("/v1/ei/frac-focus", {});
+    const response = await this.client["request"]<FracFocusRecord[] | { data: FracFocusRecord[] }>(
+      "/v1/ei/frac-focus",
+      {},
+    );
 
     return Array.isArray(response) ? response : response.data;
   }
@@ -179,10 +194,7 @@ export class EIFracFocusResource {
       throw new ValidationError("Record ID must be a non-empty string");
     }
 
-    return this.client["request"]<FracFocusRecord>(
-      `/v1/ei/frac-focus/${id}`,
-      {},
-    );
+    return this.client["request"]<FracFocusRecord>(`/v1/ei/frac-focus/${id}`, {});
   }
 
   /**
@@ -191,10 +203,7 @@ export class EIFracFocusResource {
    * @returns Latest disclosure record
    */
   async latest(): Promise<FracFocusRecord> {
-    return this.client["request"]<FracFocusRecord>(
-      "/v1/ei/frac-focus/latest",
-      {},
-    );
+    return this.client["request"]<FracFocusRecord>("/v1/ei/frac-focus/latest", {});
   }
 
   /**
@@ -203,10 +212,7 @@ export class EIFracFocusResource {
    * @returns Disclosure summary statistics
    */
   async summary(): Promise<FracFocusSummary> {
-    return this.client["request"]<FracFocusSummary>(
-      "/v1/ei/frac-focus/summary",
-      {},
-    );
+    return this.client["request"]<FracFocusSummary>("/v1/ei/frac-focus/summary", {});
   }
 
   /**
@@ -241,9 +247,10 @@ export class EIFracFocusResource {
    * @returns Array of chemicals used in fracturing
    */
   async byChemical(): Promise<ChemicalUsage[]> {
-    const response = await this.client["request"]<
-      ChemicalUsage[] | { data: ChemicalUsage[] }
-    >("/v1/ei/frac-focus/by-chemical", {});
+    const response = await this.client["request"]<ChemicalUsage[] | { data: ChemicalUsage[] }>(
+      "/v1/ei/frac-focus/by-chemical",
+      {},
+    );
 
     return Array.isArray(response) ? response : response.data;
   }
@@ -257,15 +264,22 @@ export class EIFracFocusResource {
   async search(query: FracFocusSearchQuery): Promise<FracFocusRecord[]> {
     const params: Record<string, string> = {};
 
-    if (query.state) params.state = query.state;
-    if (query.operator) params.operator = query.operator;
-    if (query.chemical) params.chemical = query.chemical;
+    if (query.states) params.states = query.states;
+    if (query.county) params.county = query.county;
+    if (query.well_name) params.well_name = query.well_name;
+    if (query.api_number) params.api_number = query.api_number;
+    if (query.min_water_gallons !== undefined)
+      params.min_water_gallons = query.min_water_gallons.toString();
+    if (query.latitude !== undefined) params.latitude = query.latitude.toString();
+    if (query.longitude !== undefined) params.longitude = query.longitude.toString();
+    if (query.radius_miles !== undefined) params.radius_miles = query.radius_miles.toString();
     if (query.start_date) params.start_date = query.start_date;
     if (query.end_date) params.end_date = query.end_date;
 
-    const response = await this.client["request"]<
-      FracFocusRecord[] | { data: FracFocusRecord[] }
-    >("/v1/ei/frac-focus/search", params);
+    const response = await this.client["request"]<FracFocusRecord[] | { data: FracFocusRecord[] }>(
+      "/v1/ei/frac-focus/search",
+      params,
+    );
 
     return Array.isArray(response) ? response : response.data;
   }
@@ -281,9 +295,10 @@ export class EIFracFocusResource {
       throw new ValidationError("Disclosure ID must be a non-empty string");
     }
 
-    const response = await this.client["request"]<
-      WellChemical[] | { chemicals: WellChemical[] }
-    >(`/v1/ei/frac-focus/${id}/chemicals`, {});
+    const response = await this.client["request"]<WellChemical[] | { chemicals: WellChemical[] }>(
+      `/v1/ei/frac-focus/${id}/chemicals`,
+      {},
+    );
 
     return Array.isArray(response) ? response : response.chemicals;
   }
@@ -299,9 +314,10 @@ export class EIFracFocusResource {
       throw new ValidationError("API number must be a non-empty string");
     }
 
-    const response = await this.client["request"]<
-      FracFocusRecord[] | { data: FracFocusRecord[] }
-    >(`/v1/ei/frac-focus/for-well/${apiNumber}`, {});
+    const response = await this.client["request"]<FracFocusRecord[] | { data: FracFocusRecord[] }>(
+      `/v1/ei/frac-focus/for-well/${apiNumber}`,
+      {},
+    );
 
     return Array.isArray(response) ? response : response.data;
   }

--- a/src/resources/ei/well-permits.ts
+++ b/src/resources/ei/well-permits.ts
@@ -92,18 +92,34 @@ export interface PermitsByFormation {
 }
 
 /**
- * Well permit search query
+ * Well permit search query.
+ *
+ * Maps to the parameters the `search` action actually reads. Note: `operator`
+ * and `formation` are NOT search params (use the dedicated by-operator /
+ * by-formation endpoints); state filtering uses `states` (comma-separated, plural).
  */
 export interface WellPermitSearchQuery {
-  /** State filter */
-  state?: string;
-  /** Operator filter */
-  operator?: string;
-  /** Formation filter */
-  formation?: string;
-  /** Start date */
+  /** Comma-separated state codes (e.g. 'TX,NM') */
+  states?: string;
+  /** County name (partial match) */
+  county?: string;
+  /** Well name (partial match) */
+  well_name?: string;
+  /** Permit type */
+  permit_type?: string;
+  /** Well type */
+  well_type?: string;
+  /** Free-form address (geocoded to lat/lng) */
+  address?: string;
+  /** Latitude for radius search */
+  latitude?: number;
+  /** Longitude for radius search */
+  longitude?: number;
+  /** Radius in miles (1-100, default 10) for lat/lng search */
+  radius_miles?: number;
+  /** Start date (permit_date >=) */
   start_date?: string;
-  /** End date */
+  /** End date (permit_date <=) */
   end_date?: string;
 }
 
@@ -158,10 +174,7 @@ export class EIWellPermitsResource {
       throw new ValidationError("Record ID must be a non-empty string");
     }
 
-    return this.client["request"]<WellPermitRecord>(
-      `/v1/ei/well-permits/${id}`,
-      {},
-    );
+    return this.client["request"]<WellPermitRecord>(`/v1/ei/well-permits/${id}`, {});
   }
 
   /**
@@ -170,10 +183,7 @@ export class EIWellPermitsResource {
    * @returns Latest well permit record
    */
   async latest(): Promise<WellPermitRecord> {
-    return this.client["request"]<WellPermitRecord>(
-      "/v1/ei/well-permits/latest",
-      {},
-    );
+    return this.client["request"]<WellPermitRecord>("/v1/ei/well-permits/latest", {});
   }
 
   /**
@@ -182,10 +192,7 @@ export class EIWellPermitsResource {
    * @returns Well permit summary statistics
    */
   async summary(): Promise<WellPermitSummary> {
-    return this.client["request"]<WellPermitSummary>(
-      "/v1/ei/well-permits/summary",
-      {},
-    );
+    return this.client["request"]<WellPermitSummary>("/v1/ei/well-permits/summary", {});
   }
 
   /**
@@ -194,9 +201,10 @@ export class EIWellPermitsResource {
    * @returns Array of permits grouped by state
    */
   async byState(): Promise<PermitsByState[]> {
-    const response = await this.client["request"]<
-      PermitsByState[] | { data: PermitsByState[] }
-    >("/v1/ei/well-permits/by-state", {});
+    const response = await this.client["request"]<PermitsByState[] | { data: PermitsByState[] }>(
+      "/v1/ei/well-permits/by-state",
+      {},
+    );
 
     return Array.isArray(response) ? response : response.data;
   }
@@ -236,9 +244,15 @@ export class EIWellPermitsResource {
   async search(query: WellPermitSearchQuery): Promise<WellPermitRecord[]> {
     const params: Record<string, string> = {};
 
-    if (query.state) params.state = query.state;
-    if (query.operator) params.operator = query.operator;
-    if (query.formation) params.formation = query.formation;
+    if (query.states) params.states = query.states;
+    if (query.county) params.county = query.county;
+    if (query.well_name) params.well_name = query.well_name;
+    if (query.permit_type) params.permit_type = query.permit_type;
+    if (query.well_type) params.well_type = query.well_type;
+    if (query.address) params.address = query.address;
+    if (query.latitude !== undefined) params.latitude = query.latitude.toString();
+    if (query.longitude !== undefined) params.longitude = query.longitude.toString();
+    if (query.radius_miles !== undefined) params.radius_miles = query.radius_miles.toString();
     if (query.start_date) params.start_date = query.start_date;
     if (query.end_date) params.end_date = query.end_date;
 

--- a/src/resources/forecasts.ts
+++ b/src/resources/forecasts.ts
@@ -159,10 +159,8 @@ export class ForecastsResource {
    * ```
    */
   async accuracy(): Promise<ForecastAccuracy> {
-    return this.client["request"]<ForecastAccuracy>(
-      "/v1/forecasts/accuracy",
-      {},
-    );
+    // Route is /v1/forecasts/monthly/accuracy (the bare /accuracy 404s).
+    return this.client["request"]<ForecastAccuracy>("/v1/forecasts/monthly/accuracy", {});
   }
 
   /**
@@ -194,13 +192,17 @@ export class ForecastsResource {
    * });
    * ```
    */
-  async archive(year?: number): Promise<ArchivedForecast[]> {
+  async archive(options?: { page?: number; perPage?: number }): Promise<ArchivedForecast[]> {
+    // Route is /v1/forecasts/monthly/archive (the bare /archive 404s). The
+    // controller reads only `page` / `per_page` — it does NOT filter by year,
+    // so the previous `year` argument was silently ignored.
     const params: Record<string, string> = {};
-    if (year) params.year = year.toString();
+    if (options?.page !== undefined) params.page = options.page.toString();
+    if (options?.perPage !== undefined) params.per_page = options.perPage.toString();
 
     const response = await this.client["request"]<
       ArchivedForecast[] | { forecasts: ArchivedForecast[] }
-    >("/v1/forecasts/archive", params);
+    >("/v1/forecasts/monthly/archive", params);
 
     return Array.isArray(response) ? response : response.forecasts;
   }
@@ -236,9 +238,6 @@ export class ForecastsResource {
     const params: Record<string, string> = {};
     if (commodity) params.commodity = commodity;
 
-    return this.client["request"]<MonthlyForecast>(
-      `/v1/forecasts/monthly/${period}`,
-      params,
-    );
+    return this.client["request"]<MonthlyForecast>(`/v1/forecasts/monthly/${period}`, params);
   }
 }

--- a/src/resources/futures.ts
+++ b/src/resources/futures.ts
@@ -45,13 +45,35 @@ export interface HistoricalFuturesPrice {
 }
 
 /**
- * Options for historical futures query
+ * Options for historical futures query.
+ *
+ * The controller reads `from` / `to` (dates) plus optional `interval` and
+ * `contracts` — NOT `start_date` / `end_date`.
  */
 export interface HistoricalFuturesOptions {
   /** Start date in ISO 8601 format (YYYY-MM-DD) */
   startDate?: string;
   /** End date in ISO 8601 format (YYYY-MM-DD) */
   endDate?: string;
+  /** Aggregation interval (e.g. '1d') */
+  interval?: string;
+  /** Specific contracts to include */
+  contracts?: string;
+}
+
+/**
+ * Options for futures OHLC query.
+ *
+ * The controller reads `days`, `contract` and `interval` — there is no `date`
+ * parameter for OHLC.
+ */
+export interface FuturesOHLCOptions {
+  /** Number of days of OHLC bars (default 30, clamped 1-365) */
+  days?: number;
+  /** Specific contract */
+  contract?: string;
+  /** Aggregation interval */
+  interval?: string;
 }
 
 /**
@@ -291,8 +313,10 @@ export class FuturesContractFamily {
    */
   async historical(options?: HistoricalFuturesOptions): Promise<HistoricalFuturesPrice[]> {
     const params: Record<string, string> = {};
-    if (options?.startDate) params.start_date = options.startDate;
-    if (options?.endDate) params.end_date = options.endDate;
+    if (options?.startDate) params.from = options.startDate;
+    if (options?.endDate) params.to = options.endDate;
+    if (options?.interval) params.interval = options.interval;
+    if (options?.contracts) params.contracts = options.contracts;
 
     const response = await this.client["request"]<
       HistoricalFuturesPrice[] | { prices: HistoricalFuturesPrice[] }
@@ -304,11 +328,13 @@ export class FuturesContractFamily {
   /**
    * Get OHLC data for this contract family.
    *
-   * @param date - Optional date (YYYY-MM-DD); defaults to latest.
+   * @param options - `{ days, contract, interval }` (the API has no `date` param here).
    */
-  async ohlc(date?: string): Promise<FuturesOHLC> {
+  async ohlc(options?: FuturesOHLCOptions): Promise<FuturesOHLC> {
     const params: Record<string, string> = {};
-    if (date) params.date = date;
+    if (options?.days !== undefined) params.days = options.days.toString();
+    if (options?.contract) params.contract = options.contract;
+    if (options?.interval) params.interval = options.interval;
     return this.client["request"]<FuturesOHLC>(`/v1/futures/${this.slug}/ohlc`, params);
   }
 

--- a/src/resources/rig-counts.ts
+++ b/src/resources/rig-counts.ts
@@ -187,12 +187,13 @@ export class RigCountsResource {
    * });
    * ```
    */
-  async historical(
-    options?: HistoricalRigCountOptions,
-  ): Promise<HistoricalRigCountData[]> {
+  async historical(options?: HistoricalRigCountOptions): Promise<HistoricalRigCountData[]> {
+    // The controller filters via `has_scope :by_period, using: %i[from to], type: :hash`,
+    // i.e. it reads nested `by_period[from]` / `by_period[to]` query params — NOT
+    // flat `start_date` / `end_date` (which were silently ignored by earlier SDKs).
     const params: Record<string, string> = {};
-    if (options?.startDate) params.start_date = options.startDate;
-    if (options?.endDate) params.end_date = options.endDate;
+    if (options?.startDate) params["by_period[from]"] = options.startDate;
+    if (options?.endDate) params["by_period[to]"] = options.endDate;
 
     const response = await this.client["request"]<
       HistoricalRigCountData[] | { data: HistoricalRigCountData[] }
@@ -224,10 +225,7 @@ export class RigCountsResource {
     const params: Record<string, string> = {};
     if (period) params.period = period;
 
-    return this.client["request"]<RigCountTrend>(
-      "/v1/rig-counts/trends",
-      params,
-    );
+    return this.client["request"]<RigCountTrend>("/v1/rig-counts/trends", params);
   }
 
   /**
@@ -253,9 +251,6 @@ export class RigCountsResource {
    * ```
    */
   async summary(): Promise<RigCountSummary> {
-    return this.client["request"]<RigCountSummary>(
-      "/v1/rig-counts/summary",
-      {},
-    );
+    return this.client["request"]<RigCountSummary>("/v1/rig-counts/summary", {});
   }
 }

--- a/src/resources/storage.ts
+++ b/src/resources/storage.ts
@@ -48,10 +48,11 @@ export interface HistoricalStorageData {
  * Options for historical storage query
  */
 export interface HistoricalStorageOptions {
-  /** Start date in ISO 8601 format (YYYY-MM-DD) */
-  startDate?: string;
-  /** End date in ISO 8601 format (YYYY-MM-DD) */
-  endDate?: string;
+  /**
+   * Lookback period. The API reads a `period` token, one of
+   * '7d' | '30d' | '90d' (default) | '1y' | 'all' — not arbitrary date ranges.
+   */
+  period?: "7d" | "30d" | "90d" | "1y" | "all";
 }
 
 /**
@@ -172,10 +173,7 @@ export class StorageResource {
     const params: Record<string, string> = {};
     if (region) params.region = region;
 
-    return this.client["request"]<StorageData | StorageData[]>(
-      "/v1/storage/regional",
-      params,
-    );
+    return this.client["request"]<StorageData | StorageData[]>("/v1/storage/regional", params);
   }
 
   /**
@@ -211,12 +209,13 @@ export class StorageResource {
     }
 
     const params: Record<string, string> = {};
-    if (options?.startDate) params.start_date = options.startDate;
-    if (options?.endDate) params.end_date = options.endDate;
+    if (options?.period) params.period = options.period;
 
+    // Route is GET /v1/storage/history/:code (the :code segment comes AFTER
+    // `history`), and the controller reads a `period` token.
     const response = await this.client["request"]<
       HistoricalStorageData[] | { data: HistoricalStorageData[] }
-    >(`/v1/storage/${code}/history`, params);
+    >(`/v1/storage/history/${code}`, params);
 
     return Array.isArray(response) ? response : response.data;
   }

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -14,18 +14,16 @@ import { verifyWebhookSignature } from "../index.js";
 export interface WebhookEndpoint {
   /** Unique webhook identifier */
   id: string;
-  /** User-friendly webhook name */
-  name: string;
+  /** User-friendly description of the webhook */
+  description?: string;
   /** Webhook URL (must be HTTPS) */
   url: string;
   /** Event types to subscribe to */
   events: string[];
-  /** Whether the webhook is active */
-  enabled: boolean;
-  /** Optional secret for signature verification */
+  /** Lifecycle status (e.g. 'active', 'disabled') */
+  status?: string;
+  /** Optional secret for signature verification (generated server-side) */
   secret?: string;
-  /** Optional metadata */
-  metadata?: Record<string, unknown>;
   /** Number of successful deliveries */
   successful_deliveries: number;
   /** Number of failed deliveries */
@@ -42,38 +40,54 @@ export interface WebhookEndpoint {
 
 /**
  * Parameters for creating a webhook
+ *
+ * NOTE: The API permits a flat (un-nested) body with the fields below. Earlier
+ * SDK versions nested these under a `webhook` key and used `name`/`enabled`,
+ * which the controller dropped — the controller reads `description` and `status`.
  */
 export interface CreateWebhookParams {
-  /** User-friendly webhook name */
-  name: string;
   /** Webhook URL (must be HTTPS) */
   url: string;
   /** Event types to subscribe to */
   events: string[];
-  /** Whether to enable immediately (default: true) */
-  enabled?: boolean;
-  /** Optional secret for signature verification */
-  secret?: string;
-  /** Optional metadata */
-  metadata?: Record<string, unknown>;
+  /** User-friendly description */
+  description?: string;
+  /** Lifecycle status (e.g. 'active', 'disabled') */
+  status?: string;
+  /** Commodity codes to filter events to */
+  commodity_filters?: string[];
+  /** US state codes to filter events to */
+  state_filters?: string[];
+  /** Per-second delivery rate limit */
+  rate_limit_per_second?: number;
+  /** Delivery timeout in seconds */
+  timeout_seconds?: number;
+  /** Max delivery retry attempts */
+  max_retries?: number;
 }
 
 /**
  * Parameters for updating a webhook
  */
 export interface UpdateWebhookParams {
-  /** User-friendly webhook name */
-  name?: string;
   /** Webhook URL */
   url?: string;
   /** Event types to subscribe to */
   events?: string[];
-  /** Whether the webhook is active */
-  enabled?: boolean;
-  /** Secret for signature verification */
-  secret?: string;
-  /** Metadata */
-  metadata?: Record<string, unknown>;
+  /** User-friendly description */
+  description?: string;
+  /** Lifecycle status (e.g. 'active', 'disabled') */
+  status?: string;
+  /** Commodity codes to filter events to */
+  commodity_filters?: string[];
+  /** US state codes to filter events to */
+  state_filters?: string[];
+  /** Per-second delivery rate limit */
+  rate_limit_per_second?: number;
+  /** Delivery timeout in seconds */
+  timeout_seconds?: number;
+  /** Max delivery retry attempts */
+  max_retries?: number;
 }
 
 /**
@@ -236,9 +250,6 @@ export class WebhooksResource {
    * ```
    */
   async create(params: CreateWebhookParams): Promise<WebhookEndpoint> {
-    if (!params.name || typeof params.name !== "string") {
-      throw new ValidationError("Webhook name is required");
-    }
     if (!params.url || !params.url.startsWith("https://")) {
       throw new ValidationError("Webhook URL must use HTTPS protocol");
     }
@@ -246,21 +257,13 @@ export class WebhooksResource {
       throw new ValidationError("At least one event type is required");
     }
 
+    // The controller reads a flat (un-nested) body via params.permit(...).
     const response = await this.client["request"]<WebhookEndpoint | { webhook: WebhookEndpoint }>(
       "/v1/webhooks",
       {},
       {
         method: "POST",
-        body: {
-          webhook: {
-            name: params.name,
-            url: params.url,
-            events: params.events,
-            enabled: params.enabled ?? true,
-            secret: params.secret,
-            metadata: params.metadata,
-          },
-        },
+        body: { ...params },
       },
     );
 
@@ -309,7 +312,7 @@ export class WebhooksResource {
       {},
       {
         method: "PATCH",
-        body: { webhook: params },
+        body: { ...params },
       },
     );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,12 +161,7 @@ export type HistoricalPeriod = "past_week" | "past_month" | "past_year";
  * response times from 74s to <1s. The 'raw' option returns individual price
  * points which can be 600k+ records for a year of BRENT data.
  */
-export type AggregationInterval =
-  | "raw"
-  | "hourly"
-  | "daily"
-  | "weekly"
-  | "monthly";
+export type AggregationInterval = "raw" | "hourly" | "daily" | "weekly" | "monthly";
 
 /**
  * Options for fetching historical prices
@@ -283,6 +278,50 @@ export interface Commodity {
  */
 export interface CommoditiesResponse {
   commodities: Commodity[];
+}
+
+/**
+ * A single price entry from the no-auth demo prices endpoint.
+ */
+export interface DemoPrice {
+  code: string;
+  name: string;
+  price: number;
+  currency: string;
+  updated_at: string;
+  change_24h?: number;
+  source?: string;
+}
+
+/**
+ * Parsed response from the no-auth `GET /v1/demo/prices` endpoint.
+ */
+export interface DemoPricesResponse {
+  prices: DemoPrice[];
+  meta: {
+    demo_mode?: boolean;
+    rate_limit?: string;
+    available_commodities?: number;
+    [key: string]: unknown;
+  };
+  examples?: unknown;
+}
+
+/**
+ * Parsed response from the no-auth `GET /v1/demo/commodities` endpoint.
+ */
+export interface DemoCommoditiesResponse {
+  /** Commodities grouped by category key. */
+  commodities: Record<string, Commodity[]>;
+  meta: {
+    /** Total number of demo-listed commodities. */
+    total: number;
+    /** Category keys present in the listing. */
+    categories: string[];
+    /** Commodity codes available on the free demo tier. */
+    free_commodities: string[];
+    [key: string]: unknown;
+  };
 }
 
 /**

--- a/tests/live/demo-endpoints.test.ts
+++ b/tests/live/demo-endpoints.test.ts
@@ -1,0 +1,59 @@
+/**
+ * LIVE contract tests for the public, no-auth demo endpoints.
+ *
+ * These hit the real API over the network:
+ *   - GET https://api.oilpriceapi.com/v1/demo/prices
+ *   - GET https://api.oilpriceapi.com/v1/demo/commodities
+ *
+ * They validate that the client parses the real wire envelope
+ * (`{ status, data: { prices|commodities, meta } }`) correctly.
+ *
+ * Excluded from the default `npm test` run (see vitest.config.ts) so offline
+ * unit runs are not affected. Run explicitly with `npm run test:live`.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { OilPriceAPI } from "../../src/client.js";
+
+describe("LIVE demo endpoints", () => {
+  let client: OilPriceAPI;
+
+  beforeAll(() => {
+    // The demo endpoints ignore auth, but the constructor still requires a key.
+    // Any placeholder works — the demo path does not send/validate it meaningfully.
+    client = new OilPriceAPI({ apiKey: "demo", retries: 1 });
+  });
+
+  it("getDemoPrices() parses the real prices envelope", async () => {
+    const res = await client.getDemoPrices();
+
+    expect(Array.isArray(res.prices)).toBe(true);
+    // The demo tier exposes a fixed set of free commodities (currently 9).
+    expect(res.prices.length).toBeGreaterThanOrEqual(5);
+
+    const brent = res.prices.find((p) => p.code === "BRENT_CRUDE_USD");
+    expect(brent, "BRENT_CRUDE_USD should be in the demo prices").toBeDefined();
+    expect(typeof brent!.price).toBe("number");
+    // Sanity range check — Brent has traded ~$60-$120/bbl historically.
+    expect(brent!.price).toBeGreaterThan(20);
+    expect(brent!.price).toBeLessThan(300);
+
+    expect(res.meta).toBeDefined();
+    expect(res.meta.demo_mode).toBe(true);
+  });
+
+  it("getDemoCommodities() parses the real commodities envelope", async () => {
+    const res = await client.getDemoCommodities();
+
+    // commodities is grouped by category key -> array of commodity metadata.
+    expect(res.commodities).toBeDefined();
+    expect(typeof res.commodities).toBe("object");
+    expect(Object.keys(res.commodities).length).toBeGreaterThan(0);
+
+    expect(res.meta).toBeDefined();
+    // Hundreds of commodities are catalogued (442 at time of writing).
+    expect(res.meta.total).toBeGreaterThan(100);
+    expect(Array.isArray(res.meta.free_commodities)).toBe(true);
+    expect(res.meta.free_commodities).toContain("BRENT_CRUDE_USD");
+    expect(res.meta.free_commodities).toContain("WTI_USD");
+  });
+});

--- a/tests/resources/analytics.test.ts
+++ b/tests/resources/analytics.test.ts
@@ -10,108 +10,186 @@ describe("AnalyticsResource", () => {
   });
 
   describe("performance()", () => {
-    it("should fetch performance metrics", async () => {
+    it("should fetch usage analytics with a range param", async () => {
       const mockData = {
-        commodity: "WTI_USD",
-        period_days: 30,
-        average_price: 75.5,
-        volatility: 2.5,
-        return_percent: 5.2,
-        high: 78.0,
-        low: 72.0,
-        timestamp: "2024-01-15T00:00:00Z",
+        overview: { totalRequests: 100 },
+        dailyUsage: [],
       };
 
-      const requestSpy = vi
-        .spyOn(client as any, "request")
-        .mockResolvedValue(mockData);
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
 
-      const result = await client.analytics.performance({
-        commodity: "WTI_USD",
-      });
+      const result = await client.analytics.performance({ range: "7d" });
 
       expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/performance", {
-        commodity: "WTI_USD",
+        range: "7d",
       });
-      expect(result.average_price).toBe(75.5);
+      expect((result.overview as any).totalRequests).toBe(100);
+    });
+
+    it("should send no params when called without options", async () => {
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue({});
+
+      await client.analytics.performance();
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/performance", {});
     });
   });
 
   describe("statistics()", () => {
-    it("should fetch statistical analysis", async () => {
+    it("should send code and period params", async () => {
       const mockData = {
-        commodity: "WTI_USD",
-        period_days: 30,
-        mean: 75.5,
-        median: 75.25,
-        std_dev: 2.5,
-        variance: 6.25,
-        min: 72.0,
-        max: 78.0,
-        timestamp: "2024-01-15T00:00:00Z",
+        code: "WTI_USD",
+        period: 30,
+        statistics: { mean: 75.5 },
       };
 
-      const requestSpy = vi
-        .spyOn(client as any, "request")
-        .mockResolvedValue(mockData);
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
 
-      const result = await client.analytics.statistics("WTI_USD");
+      const result = await client.analytics.statistics("WTI_USD", 30);
 
       expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/statistics", {
-        commodity: "WTI_USD",
+        code: "WTI_USD",
+        period: "30",
       });
-      expect(result.mean).toBe(75.5);
+      expect((result.statistics as any).mean).toBe(75.5);
+    });
+
+    it("should send only code when period omitted", async () => {
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue({});
+
+      await client.analytics.statistics("WTI_USD");
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/statistics", {
+        code: "WTI_USD",
+      });
     });
   });
 
   describe("correlation()", () => {
-    it("should calculate correlation between commodities", async () => {
+    it("should send code1/code2 (not commodity1/commodity2)", async () => {
       const mockData = {
-        commodity1: "WTI_USD",
-        commodity2: "BRENT_CRUDE_USD",
-        period_days: 30,
+        type: "analysis",
+        code1: "WTI_USD",
+        code2: "BRENT_CRUDE_USD",
+        period: 30,
         correlation: 0.95,
-        strength: "strong" as const,
-        timestamp: "2024-01-15T00:00:00Z",
+        strength: "very_strong",
       };
 
-      const requestSpy = vi
-        .spyOn(client as any, "request")
-        .mockResolvedValue(mockData);
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
 
-      const result = await client.analytics.correlation(
-        "WTI_USD",
-        "BRENT_CRUDE_USD",
-      );
+      const result = await client.analytics.correlation("WTI_USD", "BRENT_CRUDE_USD");
 
       expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/correlation", {
-        commodity1: "WTI_USD",
-        commodity2: "BRENT_CRUDE_USD",
+        code1: "WTI_USD",
+        code2: "BRENT_CRUDE_USD",
       });
       expect(result.correlation).toBe(0.95);
+    });
+
+    it("should accept a numeric period (backward compatible)", async () => {
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue({});
+
+      await client.analytics.correlation("WTI_USD", "BRENT_CRUDE_USD", 90);
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/correlation", {
+        code1: "WTI_USD",
+        code2: "BRENT_CRUDE_USD",
+        period: "90",
+      });
+    });
+
+    it("should support rolling correlation with type/window", async () => {
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue({});
+
+      await client.analytics.correlation("WTI_USD", "BRENT_CRUDE_USD", {
+        period: 60,
+        type: "rolling",
+        window: 7,
+      });
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/correlation", {
+        code1: "WTI_USD",
+        code2: "BRENT_CRUDE_USD",
+        period: "60",
+        type: "rolling",
+        window: "7",
+      });
     });
   });
 
   describe("trend()", () => {
-    it("should detect price trends", async () => {
+    it("should send code (not commodity)", async () => {
       const mockData = {
-        commodity: "WTI_USD",
-        period_days: 30,
-        trend: "upward" as const,
-        strength: 75,
-        timestamp: "2024-01-15T00:00:00Z",
+        type: "analysis",
+        code: "WTI_USD",
+        period: 30,
       };
 
-      const requestSpy = vi
-        .spyOn(client as any, "request")
-        .mockResolvedValue(mockData);
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
 
       const result = await client.analytics.trend("WTI_USD");
 
       expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/trend", {
-        commodity: "WTI_USD",
+        code: "WTI_USD",
       });
-      expect(result.trend).toBe("upward");
+      expect(result.code).toBe("WTI_USD");
+    });
+
+    it("should support indicator variants via type/window", async () => {
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue({});
+
+      await client.analytics.trend("WTI_USD", { type: "rsi", window: 14 });
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/trend", {
+        code: "WTI_USD",
+        type: "rsi",
+        window: "14",
+      });
+    });
+  });
+
+  describe("spread()", () => {
+    it("should send the named spread and period", async () => {
+      const requestSpy = vi
+        .spyOn(client as any, "request")
+        .mockResolvedValue({ type: "current", spread: "wti_brent" });
+
+      await client.analytics.spread("wti_brent", { period: 30 });
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/spread", {
+        spread: "wti_brent",
+        period: "30",
+      });
+    });
+
+    it("should send no spread param to list available spreads", async () => {
+      const requestSpy = vi
+        .spyOn(client as any, "request")
+        .mockResolvedValue({ available_spreads: [] });
+
+      await client.analytics.spread();
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/spread", {});
+    });
+  });
+
+  describe("forecast()", () => {
+    it("should send code/method/period", async () => {
+      const requestSpy = vi
+        .spyOn(client as any, "request")
+        .mockResolvedValue({ code: "WTI_USD", method: "ema" });
+
+      await client.analytics.forecast("WTI_USD", {
+        method: "ema",
+        period: 90,
+      });
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/analytics/forecast", {
+        code: "WTI_USD",
+        method: "ema",
+        period: "90",
+      });
     });
   });
 });

--- a/tests/resources/data-sources.test.ts
+++ b/tests/resources/data-sources.test.ts
@@ -13,9 +13,8 @@ import type {
 const makeDataSource = (overrides: Partial<DataSource> = {}): DataSource => ({
   id: "source-1",
   name: "Custom API Source",
-  type: "api",
-  config: { url: "https://internal.company.com/api/prices" },
-  enabled: true,
+  source_type: "api",
+  scraper_config: { url: "https://internal.company.com/api/prices" },
   status: "active",
   successful_syncs: 100,
   failed_syncs: 5,
@@ -36,7 +35,7 @@ describe("DataSourcesResource", () => {
     it("should fetch all data sources as array", async () => {
       const mockData: DataSource[] = [
         makeDataSource({ id: "source-1", name: "API Source" }),
-        makeDataSource({ id: "source-2", name: "SFTP Source", type: "sftp" }),
+        makeDataSource({ id: "source-2", name: "SFTP Source", source_type: "sftp" }),
       ];
 
       const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
@@ -46,7 +45,7 @@ describe("DataSourcesResource", () => {
       expect(requestSpy).toHaveBeenCalledWith("/v1/data-sources", {});
       expect(result).toHaveLength(2);
       expect(result[0].id).toBe("source-1");
-      expect(result[1].type).toBe("sftp");
+      expect(result[1].source_type).toBe("sftp");
     });
 
     it("should unwrap data_sources property when response is wrapped", async () => {
@@ -77,7 +76,6 @@ describe("DataSourcesResource", () => {
         name: "Custom API Source",
         last_sync_at: "2024-01-15T10:00:00Z",
         next_sync_at: "2024-01-15T11:00:00Z",
-        sync_frequency_minutes: 60,
       });
 
       const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
@@ -115,12 +113,14 @@ describe("DataSourcesResource", () => {
   });
 
   describe("create()", () => {
-    it("should create a new data source with required fields", async () => {
+    it("should create a new data source using source_type/scraper_config/credentials", async () => {
       const params: CreateDataSourceParams = {
         name: "Internal Price Feed",
-        type: "api",
-        config: {
+        source_type: "api",
+        scraper_config: {
           url: "https://internal.company.com/api/prices",
+        },
+        credentials: {
           auth_type: "bearer",
           token: "secret-token",
         },
@@ -128,9 +128,8 @@ describe("DataSourcesResource", () => {
 
       const mockCreated = makeDataSource({
         name: params.name,
-        type: params.type,
-        config: params.config,
-        sync_frequency_minutes: 60,
+        source_type: params.source_type,
+        scraper_config: params.scraper_config,
       });
 
       const requestSpy = vi
@@ -147,11 +146,10 @@ describe("DataSourcesResource", () => {
           body: {
             data_source: {
               name: params.name,
-              type: params.type,
-              config: params.config,
-              enabled: true,
-              sync_frequency_minutes: 60,
-              metadata: undefined,
+              source_type: params.source_type,
+              status: undefined,
+              credentials: params.credentials,
+              scraper_config: params.scraper_config,
             },
           },
         },
@@ -159,14 +157,13 @@ describe("DataSourcesResource", () => {
       expect(result.name).toBe("Internal Price Feed");
     });
 
-    it("should create a data source with all optional fields", async () => {
+    it("should create a data source with status set", async () => {
       const params: CreateDataSourceParams = {
         name: "SFTP Feed",
-        type: "sftp",
-        config: { host: "sftp.example.com", username: "user" },
-        enabled: false,
-        sync_frequency_minutes: 1440,
-        metadata: { team: "ops" },
+        source_type: "sftp",
+        scraper_config: { host: "sftp.example.com", username: "user" },
+        credentials: { password: "secret" },
+        status: "paused",
       };
 
       const mockCreated = makeDataSource({ ...params, status: "paused" });
@@ -183,11 +180,10 @@ describe("DataSourcesResource", () => {
           body: {
             data_source: {
               name: params.name,
-              type: params.type,
-              config: params.config,
-              enabled: false,
-              sync_frequency_minutes: 1440,
-              metadata: { team: "ops" },
+              source_type: params.source_type,
+              status: "paused",
+              credentials: params.credentials,
+              scraper_config: params.scraper_config,
             },
           },
         },
@@ -196,42 +192,31 @@ describe("DataSourcesResource", () => {
     });
 
     it("should throw error when name is missing", async () => {
-      await expect(
-        client.dataSources.create({ name: "", type: "api", config: {} }),
-      ).rejects.toThrow("Data source name is required");
+      await expect(client.dataSources.create({ name: "", source_type: "api" })).rejects.toThrow(
+        "Data source name is required",
+      );
     });
 
-    it("should throw error when type is missing", async () => {
+    it("should throw error when source_type is missing", async () => {
       await expect(
         client.dataSources.create({
           name: "My Source",
-          type: "" as any,
-          config: {},
+          source_type: "" as any,
         }),
-      ).rejects.toThrow("Data source type is required");
-    });
-
-    it("should throw error when config is missing", async () => {
-      await expect(
-        client.dataSources.create({
-          name: "My Source",
-          type: "api",
-          config: null as any,
-        }),
-      ).rejects.toThrow("Data source config is required");
+      ).rejects.toThrow("Data source source_type is required");
     });
   });
 
   describe("update()", () => {
     it("should update a data source with partial fields", async () => {
       const updateParams: UpdateDataSourceParams = {
-        enabled: false,
-        sync_frequency_minutes: 120,
+        status: "paused",
+        scraper_config: { interval: 120 },
       };
 
       const mockUpdated = makeDataSource({
-        enabled: false,
-        sync_frequency_minutes: 120,
+        status: "paused",
+        scraper_config: { interval: 120 },
       });
 
       const requestSpy = vi
@@ -248,17 +233,15 @@ describe("DataSourcesResource", () => {
           body: { data_source: updateParams },
         },
       );
-      expect(result.enabled).toBe(false);
-      expect(result.sync_frequency_minutes).toBe(120);
+      expect(result.status).toBe("paused");
     });
 
     it("should update all fields", async () => {
       const updateParams: UpdateDataSourceParams = {
         name: "Updated Source",
-        config: { url: "https://new.endpoint.com/prices" },
-        enabled: true,
-        sync_frequency_minutes: 30,
-        metadata: { updated: true },
+        scraper_config: { url: "https://new.endpoint.com/prices" },
+        credentials: { token: "rotated" },
+        status: "active",
       };
 
       const mockUpdated = makeDataSource({ ...updateParams, id: "source-1" });
@@ -279,13 +262,13 @@ describe("DataSourcesResource", () => {
     });
 
     it("should throw error for empty source ID", async () => {
-      await expect(client.dataSources.update("", { enabled: false })).rejects.toThrow(
+      await expect(client.dataSources.update("", { status: "paused" })).rejects.toThrow(
         "Data source ID must be a non-empty string",
       );
     });
 
     it("should throw error for non-string source ID", async () => {
-      await expect(client.dataSources.update(null as any, { enabled: false })).rejects.toThrow(
+      await expect(client.dataSources.update(null as any, { status: "paused" })).rejects.toThrow(
         "Data source ID must be a non-empty string",
       );
     });
@@ -474,12 +457,13 @@ describe("DataSourcesResource", () => {
 
       const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockResponse);
 
-      const result = await client.dataSources.rotateCredentials("source-1");
+      const newCreds = { token: "new-token" };
+      const result = await client.dataSources.rotateCredentials("source-1", newCreds);
 
       expect(requestSpy).toHaveBeenCalledWith(
-        "/v1/data-sources/source-1/rotate-credentials",
+        "/v1/data-sources/source-1/rotate_credentials",
         {},
-        { method: "POST" },
+        { method: "POST", body: { credentials: newCreds } },
       );
       expect(result.success).toBe(true);
       expect(result.credential_id).toBe("cred-new-456");
@@ -493,22 +477,24 @@ describe("DataSourcesResource", () => {
 
       vi.spyOn(client as any, "request").mockResolvedValue(mockResponse);
 
-      const result = await client.dataSources.rotateCredentials("source-1");
+      const result = await client.dataSources.rotateCredentials("source-1", {
+        token: "x",
+      });
 
       expect(result.success).toBe(false);
       expect(result.message).toContain("Rotation failed");
     });
 
     it("should throw error for empty source ID", async () => {
-      await expect(client.dataSources.rotateCredentials("")).rejects.toThrow(
+      await expect(client.dataSources.rotateCredentials("", { token: "x" })).rejects.toThrow(
         "Data source ID must be a non-empty string",
       );
     });
 
     it("should throw error for non-string source ID", async () => {
-      await expect(client.dataSources.rotateCredentials(null as any)).rejects.toThrow(
-        "Data source ID must be a non-empty string",
-      );
+      await expect(
+        client.dataSources.rotateCredentials(null as any, { token: "x" }),
+      ).rejects.toThrow("Data source ID must be a non-empty string");
     });
   });
 });

--- a/tests/resources/ei.test.ts
+++ b/tests/resources/ei.test.ts
@@ -245,16 +245,15 @@ describe("EnergyIntelligenceResource (ei.*)", () => {
     it("search() passes query params", async () => {
       const s = spy([]);
       await client.ei.wellPermits.search({
-        state: "Texas",
-        operator: "ConocoPhillips",
-        formation: "Wolfcamp",
+        states: "TX,NM",
+        county: "Midland",
         start_date: "2024-01-01",
         end_date: "2024-12-31",
       });
+      // Search reads `states` (plural); operator/formation are not search params.
       expect(s).toHaveBeenCalledWith("/v1/ei/well-permits/search", {
-        state: "Texas",
-        operator: "ConocoPhillips",
-        formation: "Wolfcamp",
+        states: "TX,NM",
+        county: "Midland",
         start_date: "2024-01-01",
         end_date: "2024-12-31",
       });
@@ -295,10 +294,11 @@ describe("EnergyIntelligenceResource (ei.*)", () => {
 
     it("search() passes query params", async () => {
       const s = spy([]);
-      await client.ei.fracFocus.search({ state: "Texas", chemical: "HCl" });
+      await client.ei.fracFocus.search({ states: "TX", county: "Midland" });
+      // Search reads `states` (plural); operator/chemical are not search params.
       expect(s).toHaveBeenCalledWith("/v1/ei/frac-focus/search", {
-        state: "Texas",
-        chemical: "HCl",
+        states: "TX",
+        county: "Midland",
       });
     });
 

--- a/tests/resources/forecasts.test.ts
+++ b/tests/resources/forecasts.test.ts
@@ -78,13 +78,11 @@ describe("ForecastsResource", () => {
         timestamp: "2024-01-15T00:00:00Z",
       };
 
-      const requestSpy = vi
-        .spyOn(client as any, "request")
-        .mockResolvedValue(mockData);
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
 
       const result = await client.forecasts.accuracy();
 
-      expect(requestSpy).toHaveBeenCalledWith("/v1/forecasts/accuracy", {});
+      expect(requestSpy).toHaveBeenCalledWith("/v1/forecasts/monthly/accuracy", {});
       expect(result.mape).toBe(8.5);
     });
   });

--- a/tests/resources/futures-family.test.ts
+++ b/tests/resources/futures-family.test.ts
@@ -84,9 +84,10 @@ describe("Futures contract families (issue #1)", () => {
         endDate: "2024-01-31",
       });
 
+      // Controller reads from/to, not start_date/end_date.
       expect(spy).toHaveBeenCalledWith("/v1/futures/ice-brent/historical", {
-        start_date: "2024-01-01",
-        end_date: "2024-01-31",
+        from: "2024-01-01",
+        to: "2024-01-31",
       });
     });
 
@@ -99,13 +100,14 @@ describe("Futures contract families (issue #1)", () => {
       expect(result).toEqual(prices);
     });
 
-    it("ohlc() passes date param", async () => {
+    it("ohlc() passes days/interval params (no date param exists)", async () => {
       const spy = vi.spyOn(client as any, "request").mockResolvedValue({});
 
-      await client.futures.wti().ohlc("2024-01-15");
+      await client.futures.wti().ohlc({ days: 30, interval: "1d" });
 
       expect(spy).toHaveBeenCalledWith("/v1/futures/ice-wti/ohlc", {
-        date: "2024-01-15",
+        days: "30",
+        interval: "1d",
       });
     });
 

--- a/tests/resources/rig-counts.test.ts
+++ b/tests/resources/rig-counts.test.ts
@@ -104,19 +104,20 @@ describe("RigCountsResource", () => {
         endDate: "2024-01-31",
       });
 
+      // Controller reads nested by_period[from]/by_period[to], not start_date/end_date.
       expect(requestSpy).toHaveBeenCalledWith("/v1/rig-counts/historical", {
-        start_date: "2024-01-01",
-        end_date: "2024-01-31",
+        "by_period[from]": "2024-01-01",
+        "by_period[to]": "2024-01-31",
       });
     });
 
-    it("should pass only startDate if endDate is omitted", async () => {
+    it("should pass only by_period[from] if endDate is omitted", async () => {
       const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue([]);
 
       await client.rigCounts.historical({ startDate: "2024-01-01" });
 
       expect(requestSpy).toHaveBeenCalledWith("/v1/rig-counts/historical", {
-        start_date: "2024-01-01",
+        "by_period[from]": "2024-01-01",
       });
     });
 

--- a/tests/resources/storage.test.ts
+++ b/tests/resources/storage.test.ts
@@ -217,38 +217,33 @@ describe("StorageResource", () => {
 
       const result = await client.storage.history("US");
 
-      expect(requestSpy).toHaveBeenCalledWith("/v1/storage/US/history", {});
+      // Path is /v1/storage/history/:code (code AFTER `history`).
+      expect(requestSpy).toHaveBeenCalledWith("/v1/storage/history/US", {});
       expect(result).toHaveLength(3);
       expect(result[0].date).toBe("2024-01-01");
       expect(result[2].level).toBe(450000);
     });
 
-    it("should fetch history with date filters", async () => {
+    it("should fetch history with a period token", async () => {
       const mockData: HistoricalStorageData[] = [
         { date: "2024-01-15", level: 25000, unit: "thousand_barrels" },
       ];
 
       const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
 
-      await client.storage.history("CUSHING", {
-        startDate: "2024-01-01",
-        endDate: "2024-01-31",
-      });
+      await client.storage.history("CUSHING", { period: "30d" });
 
-      expect(requestSpy).toHaveBeenCalledWith("/v1/storage/CUSHING/history", {
-        start_date: "2024-01-01",
-        end_date: "2024-01-31",
+      expect(requestSpy).toHaveBeenCalledWith("/v1/storage/history/CUSHING", {
+        period: "30d",
       });
     });
 
-    it("should pass only startDate when endDate is omitted", async () => {
+    it("should send no period param when omitted", async () => {
       const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue([]);
 
-      await client.storage.history("SPR", { startDate: "2024-01-01" });
+      await client.storage.history("SPR");
 
-      expect(requestSpy).toHaveBeenCalledWith("/v1/storage/SPR/history", {
-        start_date: "2024-01-01",
-      });
+      expect(requestSpy).toHaveBeenCalledWith("/v1/storage/history/SPR", {});
     });
 
     it("should unwrap data property when response is wrapped", async () => {

--- a/tests/resources/webhooks.test.ts
+++ b/tests/resources/webhooks.test.ts
@@ -22,10 +22,10 @@ describe("WebhooksResource", () => {
       const mockWebhooks: WebhookEndpoint[] = [
         {
           id: "webhook-1",
-          name: "Price Updates",
+          description: "Price Updates",
           url: "https://example.com/webhook",
           events: ["price.updated", "alert.triggered"],
-          enabled: true,
+          status: "active",
           successful_deliveries: 100,
           failed_deliveries: 5,
           last_delivery_status: "success",
@@ -61,10 +61,10 @@ describe("WebhooksResource", () => {
     it("should fetch a specific webhook by ID", async () => {
       const mockWebhook: WebhookEndpoint = {
         id: "webhook-1",
-        name: "Price Updates",
+        description: "Price Updates",
         url: "https://example.com/webhook",
         events: ["price.updated"],
-        enabled: true,
+        status: "active",
         successful_deliveries: 100,
         failed_deliveries: 5,
         created_at: "2024-01-01T00:00:00Z",
@@ -95,12 +95,12 @@ describe("WebhooksResource", () => {
   });
 
   describe("create()", () => {
-    it("should create a new webhook", async () => {
+    it("should create a new webhook with a flat body using description/status", async () => {
       const params: CreateWebhookParams = {
-        name: "Price Alerts",
+        description: "Price Alerts",
         url: "https://example.com/webhook",
         events: ["price.updated", "alert.triggered"],
-        enabled: true,
+        status: "active",
       };
 
       const mockWebhook: WebhookEndpoint = {
@@ -119,39 +119,25 @@ describe("WebhooksResource", () => {
       const result = await client.webhooks.create(params);
 
       expect(result).toEqual(mockWebhook);
+      // Flat (un-nested) body — the controller permits these fields directly.
       expect(requestSpy).toHaveBeenCalledWith(
         "/v1/webhooks",
         {},
         {
           method: "POST",
           body: {
-            webhook: {
-              name: params.name,
-              url: params.url,
-              events: params.events,
-              enabled: true,
-              secret: undefined,
-              metadata: undefined,
-            },
+            description: params.description,
+            url: params.url,
+            events: params.events,
+            status: "active",
           },
         },
       );
     });
 
-    it("should validate webhook name", async () => {
-      await expect(
-        client.webhooks.create({
-          name: "",
-          url: "https://example.com",
-          events: ["price.updated"],
-        }),
-      ).rejects.toThrow("Webhook name is required");
-    });
-
     it("should validate HTTPS URL", async () => {
       await expect(
         client.webhooks.create({
-          name: "Test",
           url: "http://example.com",
           events: ["price.updated"],
         }),
@@ -161,7 +147,6 @@ describe("WebhooksResource", () => {
     it("should validate events array is not empty", async () => {
       await expect(
         client.webhooks.create({
-          name: "Test",
           url: "https://example.com",
           events: [],
         }),
@@ -170,17 +155,17 @@ describe("WebhooksResource", () => {
   });
 
   describe("update()", () => {
-    it("should update a webhook", async () => {
+    it("should update a webhook with a flat body", async () => {
       const params: UpdateWebhookParams = {
-        enabled: false,
+        status: "disabled",
       };
 
       const mockWebhook: WebhookEndpoint = {
         id: "webhook-1",
-        name: "Price Alerts",
+        description: "Price Alerts",
         url: "https://example.com/webhook",
         events: ["price.updated"],
-        enabled: false,
+        status: "disabled",
         successful_deliveries: 100,
         failed_deliveries: 5,
         created_at: "2024-01-01T00:00:00Z",
@@ -193,19 +178,19 @@ describe("WebhooksResource", () => {
 
       const result = await client.webhooks.update("webhook-1", params);
 
-      expect(result.enabled).toBe(false);
+      expect(result.status).toBe("disabled");
       expect(requestSpy).toHaveBeenCalledWith(
         "/v1/webhooks/webhook-1",
         {},
         {
           method: "PATCH",
-          body: { webhook: params },
+          body: { ...params },
         },
       );
     });
 
     it("should throw error for empty webhook ID", async () => {
-      await expect(client.webhooks.update("", { enabled: false })).rejects.toThrow(
+      await expect(client.webhooks.update("", { status: "disabled" })).rejects.toThrow(
         "Webhook ID must be a non-empty string",
       );
     });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Live contract tests under tests/live/** hit the real API over the network.
+    // They are excluded from the default `npm test` run so offline/CI unit runs
+    // stay deterministic. Run them explicitly with `npm run test:live`.
+    exclude: ["**/node_modules/**", "**/dist/**", "tests/live/**"],
+  },
+});

--- a/vitest.live.config.ts
+++ b/vitest.live.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Only the live contract tests, which hit the real (no-auth) demo API.
+    include: ["tests/live/**/*.test.ts"],
+    // Network calls to the demo endpoint can be slower than unit tests.
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary

Systematic audit of the Node SDK's request **params, paths, and HTTP verbs** against the actual Rails controllers in `oilpriceapi-api`, fixing every case where the SDK sent a value the API **silently ignored** or **rejected**, or hit a **wrong path/verb**. Plus a confirmed analytics bug fix and new live demo-endpoint contract tests.

No version bump. Gates: `tsc --noEmit` clean, **374 unit tests pass**, `npm run build` OK, `npm run lint` **0 errors**.

## Confirmed analytics bug (the reported one)

`client.analytics.correlation()` sent `commodity1`/`commodity2`/`days`, but `V1::AnalyticsController#correlation` (`app/controllers/v1/analytics_controller.rb:76-81`) requires `code1`/`code2` and returns `"code1 and code2 parameters are required"`. **Fixed** — and aligned every analytics method to what the controller reads:

| Method | Now sends | Controller reads |
|---|---|---|
| `correlation` | `code1`, `code2`, `period` (+ optional `type`, `window`, `codes`) | `code1`/`code2`/`period` (+ `type`/`codes`/`window`) |
| `trend` | `code`, `period`, `type`, `window` | `code`/`period`/`type` |
| `statistics` | `code`, `period` | `code`/`period` |
| `forecast` | `code`, `method`, `period` | `code`/`method`/`period` |
| `spread` | `spread` (named), `period`, `type` | `spread`/`period`/`type` |
| `performance` | `range` (`7d`/`30d`/`90d`) | `range` |

(Was: all used `commodity`/`commodity1`/`commodity2`/`days` and `performance` was documented as commodity performance — it's actually the user's API-usage dashboard.)

## Other param / path / verb fixes found in the audit

Each was verified by reading the controller action / strong-params, not guessed.

- **webhooks** `create`/`update`: sent a nested `{ webhook: { name, enabled, secret, metadata, ... } }` body; `webhook_params` is a **flat** `params.permit(...)` reading `description`/`status` (not `name`/`enabled`) and does not accept `secret`/`metadata` on input → everything was dropped. Now sends a flat body with `description`/`status` + the real permitted fields.
- **data-sources** `create`/`update`: sent `type`/`config`/`enabled`/`sync_frequency_minutes`/`metadata`; `data_source_params` reads `source_type`/`scraper_config`/`status`/`credentials` → most fields dropped. Fixed. `rotateCredentials` posted to `/rotate-credentials` with no body; route is `/rotate_credentials` (underscore) and the action does `params.require(:credentials)` → now POSTs the required `{ credentials }` body to the correct path.
- **rig-counts** `historical`: sent flat `start_date`/`end_date`; controller uses `has_scope :by_period, using: %i[from to], type: :hash` → reads nested `by_period[from]`/`by_period[to]`. Fixed (flat dates were ignored).
- **storage** `history`: used `/v1/storage/:code/history` + `start_date`/`end_date`; real route is `/v1/storage/history/:code` and the action reads a `period` token (`7d`/`30d`/`90d`/`1y`/`all`). Fixed path + params.
- **bunker-fuels**:
  - `all()` called `/v1/bunker-fuels` (no route) → now `/v1/bunker-fuels/all`.
  - `spreads()` called `/v1/bunker-fuels/spreads` (no route) with no params → now `/v1/bunker-fuels/spreads/ports` reading `from`/`to`/`grade` (it's a port-to-port spread).
  - `historical()` used `/v1/bunker-fuels/historical` with `port`/`fuel_type`/`start_date`/`end_date` query params; real route is `/v1/bunker-fuels/historical/:port_code` reading `from`/`to`/`interval` (no per-fuel filter). Fixed path + params; dropped the unused `fuelType` arg.
- **forecasts**: `accuracy()`/`archive()` used `/v1/forecasts/accuracy` and `/v1/forecasts/archive`; real routes are `/v1/forecasts/monthly/accuracy` and `/v1/forecasts/monthly/archive`. `archive` now uses `page`/`per_page` — the old `year` argument was never read by the controller.
- **futures (typed families, e.g. `brent()`)**: `historical` sent `start_date`/`end_date` but `process_historical` reads `from`/`to` (+`interval`/`contracts`); `ohlc` sent `date` but `process_ohlc` reads `days`/`contract`/`interval` (no `date`). Fixed.
- **ei well-permits / frac-focus `search`**: sent `state` (singular) + `operator`/`formation`/`chemical`; the search actions read `states` (plural, comma-separated) plus geospatial/text filters (`county`, `well_name`, `lat`/`lng`/`radius_miles`, `permit_type`/`well_type`, `api_number`, `min_water_gallons`) and `start_date`/`end_date`. `operator`/`formation`/`chemical` are **not** search params (separate by-operator/by-formation/by-chemical endpoints). Realigned the query types and dropped the ignored fields.

### Server-side findings (out of scope to fix in the SDK)

The audit also surfaced endpoints whose **routes exist but the controller action does not**, so they'd 500 with `ActionNotFound` regardless of the SDK: `storage#spr`, `storage#regional`, and `drilling_intelligence#index/latest/trends/basin`. These are Rails-side gaps in `oilpriceapi-api` — flagged here, not changed in this SDK PR (removing the SDK methods would be a breaking change and wouldn't fix the API).

## Demo-endpoint contract tests (no API key)

Added `client.getDemoPrices()` and `client.getDemoCommodities()` hitting the public no-auth endpoints `GET /v1/demo/prices` and `GET /v1/demo/commodities`, parsing the real `{ status, data: { prices | commodities, meta } }` envelope (the demo `meta` block, incl. `meta.free_commodities`, is preserved rather than stripped by the latest/historical shaper).

`tests/live/demo-endpoints.test.ts` asserts real wire behavior — 9 demo prices incl. `BRENT_CRUDE_USD` (~$80, range-checked), 442 commodities, `meta.free_commodities` contains `BRENT_CRUDE_USD`/`WTI_USD`. **Marked as a live test**: it's excluded from the default `npm test` run via `vitest.config.ts` and runs only via **`npm run test:live`** (separate `vitest.live.config.ts`), so offline/CI unit runs stay deterministic.

Verified live: `npm run test:live` → 2 passed against the real API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)