### PR TITLE
chore: release 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Official Node.js SDK for Oil Price API - Real-time and historical oil & commodity prices",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,7 +7,7 @@
  * - X-Client-Version header
  * - Package.json (should match)
  */
-export const SDK_VERSION = "0.8.2";
+export const SDK_VERSION = "0.9.0";
 
 /**
  * SDK identifier used in User-Agent and X-Api-Client headers


### PR DESCRIPTION
Version bump for release: WebSocket streaming client + analytics/webhooks/data-sources/etc param-correctness fixes + live demo contract tests. Cutting v0.9.0 after merge publishes via OIDC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK version from 0.8.2 to 0.9.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->