### PR TITLE
docs: normalize legacy plan names to current tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,8 +645,8 @@ logs.forEach((log) => {
 
 Stream live price updates over a persistent WebSocket connection instead of
 polling. Streaming uses the server's ActionCable `/cable` endpoint and the
-`EnergyPricesChannel`, and is available on the **Reservoir Mastery
-(Professional+)** plan.
+`EnergyPricesChannel`, and is available on the **Professional plan
+($99/mo) or higher**.
 
 The `client.stream.prices()` method returns a subscription handle (an
 `EventEmitter`). It performs the ActionCable handshake, answers server pings,

--- a/examples/streaming.ts
+++ b/examples/streaming.ts
@@ -2,8 +2,8 @@
  * Real-time Streaming Example (WebSocket)
  *
  * Streams live oil & natural-gas price updates over the OilPriceAPI
- * ActionCable `/cable` endpoint. Requires a Reservoir Mastery (Professional+)
- * plan and a valid API key.
+ * ActionCable `/cable` endpoint. Requires a Professional plan ($99/mo) or
+ * higher and a valid API key.
  *
  * Run:
  *   OILPRICEAPI_KEY=your_key npx tsx examples/streaming.ts

--- a/src/client.ts
+++ b/src/client.ts
@@ -186,7 +186,7 @@ export class OilPriceAPI {
   /**
    * Real-time price streaming resource (WebSocket / ActionCable).
    *
-   * Streaming requires a Reservoir Mastery (Professional+) plan.
+   * Streaming requires a Professional plan ($99/mo) or higher.
    */
   public readonly stream: StreamingResource;
 

--- a/src/resources/streaming.ts
+++ b/src/resources/streaming.ts
@@ -4,7 +4,7 @@
  * Real-time price streaming via the OilPriceAPI ActionCable endpoint
  * (`wss://api.oilpriceapi.com/cable`).
  *
- * Streaming is a **Reservoir Mastery (Professional+)** feature. Connections
+ * Streaming is a **Professional plan ($99/mo) or higher** feature. Connections
  * authenticate with your API key and subscribe to the `EnergyPricesChannel`,
  * which pushes an initial `welcome` snapshot followed by live `price_update`
  * and (for drilling-tier accounts) `rig_count_update` messages.
@@ -112,7 +112,7 @@ export interface WelcomeMessage {
 }
 
 /**
- * Rig-count update broadcast (drilling / Reservoir Mastery accounts).
+ * Rig-count update broadcast (drilling / Professional+ accounts).
  */
 export interface RigCountUpdateMessage {
   type: "rig_count_update";
@@ -319,8 +319,8 @@ export class PriceStreamSubscription extends EventEmitter {
       this.emit(
         "error",
         new Error(
-          "WebSocket subscription rejected. Streaming requires a Reservoir Mastery " +
-            "(Professional+) plan and a valid API key.",
+          "WebSocket subscription rejected. Streaming requires a Professional " +
+            "plan ($99/mo) or higher and a valid API key.",
         ),
       );
       return;

--- a/tests/resources/streaming.test.ts
+++ b/tests/resources/streaming.test.ts
@@ -186,7 +186,7 @@ describe("StreamingResource", () => {
       ws.serverSend({ identifier: "{}", type: "reject_subscription" });
 
       expect(onError).toHaveBeenCalledOnce();
-      expect((onError.mock.calls[0][0] as Error).message).toMatch(/Reservoir Mastery/);
+      expect((onError.mock.calls[0][0] as Error).message).toMatch(/Professional plan/);
       handle.close();
     });
   });


### PR DESCRIPTION
Replaces the legacy **Reservoir Mastery** tier name in streaming-related docs, comments, the example, and the WebSocket subscription-rejected error message with current billing language.

Streaming / WebSocket gates at **Professional plan ($99/mo) or higher** per `GET /billing/plans`.

## Changes
- `README.md` — streaming section availability line.
- `examples/streaming.ts` — header comment.
- `src/client.ts` — `stream` resource doc comment.
- `src/resources/streaming.ts` — module doc comment, rig-count comment, and the runtime `reject_subscription` error message string.
- `tests/resources/streaming.test.ts` — updated the assertion regex (`/Reservoir Mastery/` → `/Professional plan/`) to match the new error string.

Comments/strings only; no functional code paths changed. `npm run build` passes; streaming test suite passes (17/17). No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)