### PR TITLE
ci: skip live tests on 429 (shared-key rate-limit resilience)

### DIFF
--- a/tests/live/demo-endpoints.test.ts
+++ b/tests/live/demo-endpoints.test.ts
@@ -13,6 +13,7 @@
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { OilPriceAPI } from "../../src/client.js";
+import { sleep, RATE_LIMIT_DELAY_MS, skipIfRateLimited } from "./helpers.js";
 
 describe("LIVE demo endpoints", () => {
   let client: OilPriceAPI;
@@ -23,37 +24,49 @@ describe("LIVE demo endpoints", () => {
     client = new OilPriceAPI({ apiKey: "demo", retries: 1 });
   });
 
-  it("getDemoPrices() parses the real prices envelope", async () => {
-    const res = await client.getDemoPrices();
+  it("getDemoPrices() parses the real prices envelope", async (ctx) => {
+    try {
+      const res = await client.getDemoPrices();
 
-    expect(Array.isArray(res.prices)).toBe(true);
-    // The demo tier exposes a fixed set of free commodities (currently 9).
-    expect(res.prices.length).toBeGreaterThanOrEqual(5);
+      expect(Array.isArray(res.prices)).toBe(true);
+      // The demo tier exposes a fixed set of free commodities (currently 9).
+      expect(res.prices.length).toBeGreaterThanOrEqual(5);
 
-    const brent = res.prices.find((p) => p.code === "BRENT_CRUDE_USD");
-    expect(brent, "BRENT_CRUDE_USD should be in the demo prices").toBeDefined();
-    expect(typeof brent!.price).toBe("number");
-    // Sanity range check — Brent has traded ~$60-$120/bbl historically.
-    expect(brent!.price).toBeGreaterThan(20);
-    expect(brent!.price).toBeLessThan(300);
+      const brent = res.prices.find((p) => p.code === "BRENT_CRUDE_USD");
+      expect(brent, "BRENT_CRUDE_USD should be in the demo prices").toBeDefined();
+      expect(typeof brent!.price).toBe("number");
+      // Sanity range check — Brent has traded ~$60-$120/bbl historically.
+      expect(brent!.price).toBeGreaterThan(20);
+      expect(brent!.price).toBeLessThan(300);
 
-    expect(res.meta).toBeDefined();
-    expect(res.meta.demo_mode).toBe(true);
+      expect(res.meta).toBeDefined();
+      expect(res.meta.demo_mode).toBe(true);
+    } catch (e) {
+      skipIfRateLimited(e, ctx);
+    } finally {
+      await sleep(RATE_LIMIT_DELAY_MS);
+    }
   });
 
-  it("getDemoCommodities() parses the real commodities envelope", async () => {
-    const res = await client.getDemoCommodities();
+  it("getDemoCommodities() parses the real commodities envelope", async (ctx) => {
+    try {
+      const res = await client.getDemoCommodities();
 
-    // commodities is grouped by category key -> array of commodity metadata.
-    expect(res.commodities).toBeDefined();
-    expect(typeof res.commodities).toBe("object");
-    expect(Object.keys(res.commodities).length).toBeGreaterThan(0);
+      // commodities is grouped by category key -> array of commodity metadata.
+      expect(res.commodities).toBeDefined();
+      expect(typeof res.commodities).toBe("object");
+      expect(Object.keys(res.commodities).length).toBeGreaterThan(0);
 
-    expect(res.meta).toBeDefined();
-    // Hundreds of commodities are catalogued (442 at time of writing).
-    expect(res.meta.total).toBeGreaterThan(100);
-    expect(Array.isArray(res.meta.free_commodities)).toBe(true);
-    expect(res.meta.free_commodities).toContain("BRENT_CRUDE_USD");
-    expect(res.meta.free_commodities).toContain("WTI_USD");
+      expect(res.meta).toBeDefined();
+      // Hundreds of commodities are catalogued (442 at time of writing).
+      expect(res.meta.total).toBeGreaterThan(100);
+      expect(Array.isArray(res.meta.free_commodities)).toBe(true);
+      expect(res.meta.free_commodities).toContain("BRENT_CRUDE_USD");
+      expect(res.meta.free_commodities).toContain("WTI_USD");
+    } catch (e) {
+      skipIfRateLimited(e, ctx);
+    } finally {
+      await sleep(RATE_LIMIT_DELAY_MS);
+    }
   });
 });

--- a/tests/live/futures.test.ts
+++ b/tests/live/futures.test.ts
@@ -17,15 +17,12 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { OilPriceAPI } from "../../src/client.js";
 import type { FuturesCurveData, FuturesPrice } from "../../src/resources/futures.js";
+import { sleep, RATE_LIMIT_DELAY_MS, skipIfRateLimited } from "./helpers.js";
 
 const API_KEY = process.env.OILPRICEAPI_TEST_KEY;
 
 // Skip the entire suite (rather than fail) when no key is available.
 const describeLive = API_KEY ? describe : describe.skip;
-
-/** Space requests to respect the 1 req/sec rate limit. */
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-const RATE_LIMIT_DELAY_MS = 1100;
 
 /**
  * Assert the latest payload is the real TOP-LEVEL futures response shape.
@@ -104,16 +101,26 @@ describeLive("LIVE futures latest endpoints (v0.9.1 path fix)", () => {
     client = new OilPriceAPI({ apiKey: API_KEY as string, retries: 1 });
   });
 
-  it("client.futures.brent().latest() returns the top-level response with front_month.last_price (GET /v1/futures/ice-brent)", async () => {
-    const res = await client.futures.brent().latest();
-    expectSaneFuturesPayload(res);
-    await sleep(RATE_LIMIT_DELAY_MS);
+  it("client.futures.brent().latest() returns the top-level response with front_month.last_price (GET /v1/futures/ice-brent)", async (ctx) => {
+    try {
+      const res = await client.futures.brent().latest();
+      expectSaneFuturesPayload(res);
+    } catch (e) {
+      skipIfRateLimited(e, ctx);
+    } finally {
+      await sleep(RATE_LIMIT_DELAY_MS);
+    }
   });
 
-  it("client.futures.brent().curve() returns curve data OR the documented no-data response (tolerant)", async () => {
-    const res = await client.futures.brent().curve();
-    expectSaneCurveOrNoData(res);
-    await sleep(RATE_LIMIT_DELAY_MS);
+  it("client.futures.brent().curve() returns curve data OR the documented no-data response (tolerant)", async (ctx) => {
+    try {
+      const res = await client.futures.brent().curve();
+      expectSaneCurveOrNoData(res);
+    } catch (e) {
+      skipIfRateLimited(e, ctx);
+    } finally {
+      await sleep(RATE_LIMIT_DELAY_MS);
+    }
   });
 
   // Note: the shared CI test key is rate-limited to ~1 req/sec. We keep the live

--- a/tests/live/helpers.ts
+++ b/tests/live/helpers.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared helpers for the LIVE contract suites under `tests/live/**`.
+ *
+ * The live tests authenticate with a SHARED CI test key that is rate-limited to
+ * ~1 request/second. When several repos/CI jobs exercise that key at once, the
+ * API legitimately returns HTTP 429 (rate limit). A 429 is NOT a defect in the
+ * SDK or the endpoint under test — it is cross-repo contention on the shared
+ * key. Failing the build on it red-flags otherwise-green code.
+ *
+ * `skipIfRateLimited` lets a live test treat a 429 as a SKIP (not a failure):
+ * pass it the caught error and the Vitest test context. If the error is a
+ * rate-limit error (HTTP 429 / `RateLimitError`) the current test is marked
+ * skipped with a clear message; any other error is re-thrown so real failures
+ * still fail the build.
+ */
+import { RateLimitError } from "../../src/errors.js";
+
+/** Vitest test context shape we rely on (just the dynamic `skip`). */
+export interface SkippableTaskContext {
+  skip: (note?: string) => void;
+}
+
+/** Space requests to respect the ~1 req/sec rate limit on the shared key. */
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Inter-test delay (ms). Must be >= 1.1s to stay under the 1 req/sec limit and
+ * reduce 429s in the first place.
+ */
+export const RATE_LIMIT_DELAY_MS = 1100;
+
+/** True when the error represents an HTTP 429 rate-limit response. */
+export function isRateLimitError(e: unknown): boolean {
+  if (e instanceof RateLimitError) return true;
+  // Defensive duck-typing in case the error crosses a module/realm boundary
+  // (different `instanceof` identity) but still carries the 429 signal.
+  const err = e as { statusCode?: number; status?: number; name?: string } | null;
+  return !!err && (err.statusCode === 429 || err.status === 429 || err.name === "RateLimitError");
+}
+
+/**
+ * If `e` is a rate-limit (429) error, mark the current test SKIPPED with a
+ * clear message and return. Otherwise re-throw so genuine failures still fail.
+ *
+ * Usage:
+ *   it("...", async (ctx) => {
+ *     try {
+ *       const res = await client.someLiveCall();
+ *       expect(res)...;
+ *     } catch (e) {
+ *       skipIfRateLimited(e, ctx);
+ *     }
+ *   });
+ */
+export function skipIfRateLimited(e: unknown, ctx: SkippableTaskContext): void {
+  if (isRateLimitError(e)) {
+    ctx.skip(
+      "Skipped: shared CI test key hit its rate limit (HTTP 429). " +
+        "This is cross-repo rate-limit contention, not an SDK/endpoint failure.",
+    );
+    return;
+  }
+  throw e;
+}

--- a/tests/live/subscriptions.test.ts
+++ b/tests/live/subscriptions.test.ts
@@ -13,12 +13,10 @@
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { OilPriceAPI } from "../../src/client.js";
+import { sleep, RATE_LIMIT_DELAY_MS, skipIfRateLimited } from "./helpers.js";
 
 const API_KEY = process.env.OILPRICEAPI_TEST_KEY;
 const describeLive = API_KEY ? describe : describe.skip;
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-const RATE_LIMIT_DELAY_MS = 1100;
 
 describeLive("LIVE #3245 endpoints (market-brief + subscriptions)", () => {
   let client: OilPriceAPI;
@@ -27,25 +25,34 @@ describeLive("LIVE #3245 endpoints (market-brief + subscriptions)", () => {
     client = new OilPriceAPI({ apiKey: API_KEY as string, retries: 1 });
   });
 
-  it("getMarketBrief(['BRENT_CRUDE_USD']) returns a brief with a numeric price", async () => {
-    const brief = await client.getMarketBrief(["BRENT_CRUDE_USD"]);
+  it("getMarketBrief(['BRENT_CRUDE_USD']) returns a brief with a numeric price", async (ctx) => {
+    try {
+      const brief = await client.getMarketBrief(["BRENT_CRUDE_USD"]);
 
-    expect(brief).toBeDefined();
-    expect(Array.isArray(brief.commodities)).toBe(true);
-    expect(brief.commodities.length).toBeGreaterThan(0);
+      expect(brief).toBeDefined();
+      expect(Array.isArray(brief.commodities)).toBe(true);
+      expect(brief.commodities.length).toBeGreaterThan(0);
 
-    const brent =
-      brief.commodities.find((c) => c.code === "BRENT_CRUDE_USD") ?? brief.commodities[0];
-    expect(typeof brent.price).toBe("number");
-    expect(brent.price).toBeGreaterThan(0);
-    expect(brent.price).toBeLessThan(100000);
-
-    await sleep(RATE_LIMIT_DELAY_MS);
+      const brent =
+        brief.commodities.find((c) => c.code === "BRENT_CRUDE_USD") ?? brief.commodities[0];
+      expect(typeof brent.price).toBe("number");
+      expect(brent.price).toBeGreaterThan(0);
+      expect(brent.price).toBeLessThan(100000);
+    } catch (e) {
+      skipIfRateLimited(e, ctx);
+    } finally {
+      await sleep(RATE_LIMIT_DELAY_MS);
+    }
   });
 
-  it("subscriptions.list() returns an array (200)", async () => {
-    const subs = await client.subscriptions.list();
-    expect(Array.isArray(subs)).toBe(true);
-    await sleep(RATE_LIMIT_DELAY_MS);
+  it("subscriptions.list() returns an array (200)", async (ctx) => {
+    try {
+      const subs = await client.subscriptions.list();
+      expect(Array.isArray(subs)).toBe(true);
+    } catch (e) {
+      skipIfRateLimited(e, ctx);
+    } finally {
+      await sleep(RATE_LIMIT_DELAY_MS);
+    }
   });
 });


### PR DESCRIPTION
## Problem

The live contract suites under `tests/live/**` authenticate with a **shared CI test key rate-limited to ~1 req/sec**. When multiple repos/CI jobs hit that key concurrently, the API legitimately returns **HTTP 429**. A 429 is cross-repo rate-limit contention on the shared key — not an SDK or endpoint defect — yet it currently fails the build and red-flags otherwise-green code.

## Change

- **New `tests/live/helpers.ts`** with `skipIfRateLimited(e, ctx)`:
  - Re-throws any non-429 error so genuine failures still fail the build.
  - On `RateLimitError` / HTTP 429, marks the current test **SKIPPED** (Vitest runtime `ctx.skip()`) with a clear message.
  - Also exports shared `sleep` + `RATE_LIMIT_DELAY_MS` (1100ms).
- Wrapped **every live API call** in the demo-endpoints, futures, and subscriptions live suites in `try { ... } catch (e) { skipIfRateLimited(e, ctx) } finally { await sleep(RATE_LIMIT_DELAY_MS) }`.
- Added the **>= 1.1s inter-test delay to the demo-endpoints suite** (it had none) to reduce 429s up front. Futures and subscriptions already spaced their calls and now share the helper's `sleep`/`RATE_LIMIT_DELAY_MS`.

## Preserved behavior

- Existing "skip the whole keyed suite when `OILPRICEAPI_TEST_KEY` is absent" gate is unchanged.
- No changes to non-live unit tests. **No version bump.**

## Gates

- `npx tsc --noEmit` clean (verified live test files type-check with project compiler options too).
- `npm test` green — 422 passed, 1 pre-existing skip (live suites excluded from default run).
- `npm run build` clean.
- `npm run test:live` without a key: keyed suites skip, demo suite passes — passes-or-skips cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)