### PR TITLE
fix: live-tests workflow invalid + README dependency claim (#25)

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -30,9 +30,15 @@ jobs:
         run: npm ci
 
       - name: Run live tests
-        # Guard at the step level too: skip if the secret is empty so the job
-        # is a no-op (green) rather than a failure when no key is configured.
-        if: ${{ secrets.OILPRICEAPI_TEST_KEY != '' }}
-        run: npm run test:live
+        # Shell-level guard: the `secrets` context is NOT available in step
+        # `if:` conditions — using it there makes GitHub reject the ENTIRE
+        # workflow file (red X on every push, tests never ran — issue #25).
+        # Same pattern as python-sdk: skip gracefully when no key (forks).
+        run: |
+          if [ -z "$OILPRICEAPI_TEST_KEY" ]; then
+            echo "OILPRICEAPI_TEST_KEY not set — skipping live tests (fork or unconfigured)."
+            exit 0
+          fi
+          npm run test:live
         env:
           OILPRICEAPI_TEST_KEY: ${{ secrets.OILPRICEAPI_TEST_KEY }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official Node.js/TypeScript SDK for [OilPriceAPI](https://www.oilpriceapi.co
 
 - ✅ **Simple** - Get started in 5 lines of code
 - 🔒 **Type-Safe** - Full TypeScript support with detailed type definitions
-- ⚡ **Fast** - Zero dependencies, uses native fetch (Node 18+)
+- ⚡ **Fast** - No runtime dependencies except `ws` (WebSocket streaming), uses native fetch (Node 18+)
 - 🎯 **Comprehensive** - Covers all API endpoints including diesel prices & alerts
 - 🚀 **Modern** - ES Modules, async/await, Promise-based
 - 🛡️ **Robust** - Custom error classes for better error handling


### PR DESCRIPTION
Closes #25. The step-level `if: ${{ secrets.OILPRICEAPI_TEST_KEY != '' }}` invalidated the entire workflow — red X on every main push since the workflow landed; live tests never executed. Shell-level guard now (same as python-sdk). README 'zero dependencies' → qualified (ws for streaming).

Acceptance: this PR's own run should show the workflow VALID (live job runs or skips gracefully, no 'invalid workflow file' annotation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)