### PR TITLE
docs: embedder-segment quick start (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ const prices = await client.getLatestPrices();
 console.log(prices);
 ```
 
+## Beyond Oil — Gas, LNG, Carbon & Fuels
+
+The same client covers EU ETS carbon, European gas (TTF), LNG (JKM), and marine/road/aviation fuels — for maritime compliance (EU ETS / FuelEU Maritime), fleet & logistics fuel costing, LNG and European gas analytics, and CBAM reporting.
+
+```typescript
+// EU ETS carbon allowances (EUAs) — typed futures helper
+const eua = await client.futures.euaCarbon().latest();
+console.log(eua.front_month?.last_price); // €XX.XX per tonne CO2
+
+// Dutch TTF natural gas — front month + full forward curve
+// (also: .lngJkm(), .naturalGas(), .ukCarbon(), .brent(), .wti(), .gasoil())
+const ttf = await client.futures.ttfGas().latest();
+console.log(ttf.front_month?.last_price); // €XX.XX/MWh
+
+// Marine and aviation fuels — spot prices by commodity code
+const [vlsfo] = await client.getLatestPrices({ commodity: "VLSFO_USD" });
+const [jet] = await client.getLatestPrices({ commodity: "JET_FUEL_USD" });
+console.log(vlsfo.formatted, jet.formatted); // $XXX.XX $X.XX
+```
+
+More spot codes for these markets: `EU_CARBON_EUR`, `DUTCH_TTF_EUR`, `JKM_LNG_USD`, `DIESEL_USD`, `NATURAL_GAS_USD` — and `client.bunkerFuels` for port-level VLSFO/MGO/IFO380. (Futures and bunker endpoints require a plan with futures data — spot prices work on every tier.)
+
 ## Usage Examples
 
 ### Get Latest Prices (All Commodities)


### PR DESCRIPTION
Addresses the README half of #26.

## "Beyond Oil — Gas, LNG, Carbon & Fuels"

New compact section immediately after the Quick Start example (Brent/WTI stays first). Three runnable TypeScript examples using the real typed surface:

- `client.futures.euaCarbon().latest()` — EU ETS carbon (EUA) front month
- `client.futures.ttfGas().latest()` — Dutch TTF, with the other family helpers (`.lngJkm()`, `.naturalGas()`, `.ukCarbon()`, ...) called out
- `client.getLatestPrices({ commodity: "VLSFO_USD" })` / `"JET_FUEL_USD"` — marine + aviation fuel spot

One sentence names the audiences: maritime compliance (EU ETS / FuelEU Maritime), fleet & logistics fuel costing, LNG/European gas analytics, CBAM reporting. Closes with the remaining spot codes (`EU_CARBON_EUR`, `DUTCH_TTF_EUR`, `JKM_LNG_USD`, `DIESEL_USD`, `NATURAL_GAS_USD`) and a pointer to `client.bunkerFuels`, plus a tier note (futures/bunker endpoints are plan-gated, spot works on every tier).

Notes on accuracy:

- Helper names verified in `src/resources/futures.ts` (`ttfGas`, `lngJkm`, `euaCarbon`, `ukCarbon` all exist and return `FuturesContractFamily` with `.latest()`); `front_month?.last_price` matches the `FuturesPrice` / `FuturesContractMonth` types.
- Commodity codes verified against the backend commodities config.
- I deliberately used spot codes rather than `client.bunkerFuels.port()` for the VLSFO example: the SDK's `PortBunkerPrices.prices` type is a keyed object (`prices.VLSFO`), but the live API returns `prices` as an **array** of `{grade, price, unit}` records — a keyed-access example would type-check yet print `undefined`. Worth a follow-up issue to fix the type.
- No fabricated price values — placeholder shapes only.

## Open question for Karl (from #26)

The **1.0.0 version bump is intentionally NOT included** — that call is Karl's. Current version stays 0.10.0; #26 remains open for the versioning decision.

## Verification

- `npm test`: 422 passed, 1 skipped (28 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
