### PR TITLE
release: v1.0.0 — stable API + bunker port type fix (#26, #29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-07-03
+
+First stable release. The public API surface is now covered by semantic
+versioning: breaking changes will only ship in major versions.
+
+### Breaking
+
+- **Bunker fuels response types corrected to match the live API** (#29):
+  - `bunkerFuels.port()`: `prices` is an **array** of per-grade entries
+    (`{ grade, grade_name, price, currency, unit, change_24h, change_pct_24h, last_updated, ... }`),
+    not a `{ VLSFO: number }` keyed object. `port` is an info object
+    (`{ code, name, country, ... }`), not a string. Response also includes
+    `spreads` and `metadata` blocks.
+  - `bunkerFuels.all()` returns `{ ports, metadata }` with port data keyed by
+    port code (previously typed as a flat array; at runtime it returned
+    `undefined` because the declared shape never matched the API).
+  - `bunkerFuels.compare()` returns `{ comparison, spreads, metadata }` with
+    per-port data keyed by port code (previously typed as `{ fuel_type, ports: [...] }`).
+  - `bunkerFuels.spreads()` returns `{ from_port, to_port, fuel_grade, spreads, metadata }`.
+  - `bunkerFuels.historical()` returns `{ port, historical_data, period, metadata }`
+    (previously typed as a flat array; at runtime it returned `undefined`).
+  - `bunkerFuels.export()` is typed as `BunkerExportRow[]` (JSON format).
+  - New exported types: `BunkerPortInfo`, `BunkerSpreadValue`,
+    `BunkerResponseMetadata`, `PortPricesEntry`, `AllBunkerPrices`,
+    `PortToPortSpreadDetail`, `HistoricalBunkerData`, `BunkerExportRow`.
+    `BunkerFuelPrice`, `PortBunkerPrices`, `PortPriceComparison`,
+    `BunkerFuelSpreads`, and `HistoricalBunkerPrice` have new shapes.
+
+### Fixed
+
+- README bunker examples now use valid 3-letter port codes (`SIN`, not
+  `SGSIN` — the route only accepts `[A-Z]{3}`) and the correct
+  `compare(["SIN", "RTM"])` signature.
+
 ## [0.7.0] - 2026-02-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ The official Node.js/TypeScript SDK for [OilPriceAPI](https://www.oilpriceapi.co
 - 🔄 **Resilient** - Automatic retries with exponential backoff
 - ⏱️ **Reliable** - Request timeouts and smart error handling
 - 🐛 **Debuggable** - Built-in debug logging mode
-- ⛽ **NEW v0.4.0** - Diesel prices (state averages + station-level pricing)
-- 🔔 **NEW v0.5.0** - Price alerts with webhook notifications
-- 📊 **NEW v0.7.0** - Futures, storage, rig counts, analytics, drilling intelligence, webhooks, and energy intelligence
+- ⛽ Diesel prices (state averages + station-level pricing)
+- 🔔 Price alerts with webhook notifications
+- 📊 Futures, storage, rig counts, analytics, drilling intelligence, webhooks, and energy intelligence
 - 🧰 **NEW** - Typed ICE Brent / Gasoil / WTI & gas/carbon futures helpers, `spreads`, `indicators`, and raw HTTP responses (`client.raw.*` with status + headers)
-- 🤖 **NEW v0.10.0** - `getMarketBrief()` (multi-commodity structured + narrative summary) and agent `subscriptions` (persistent watches + event polling)
+- 🤖 `getMarketBrief()` (multi-commodity structured + narrative summary) and agent `subscriptions` (persistent watches + event polling)
 
 ## Installation
 
@@ -130,7 +130,7 @@ const prices = await client.getHistoricalPrices({
 console.log(`Got ${prices.length} data points for 2024`);
 ```
 
-### Performance Optimization (New in v0.6.0)
+### Performance Optimization
 
 For year-long queries, use the `interval` parameter to dramatically improve response times:
 
@@ -149,7 +149,7 @@ console.log(`Got ${yearlyPrices.length} daily averages`);
 // Only use 'raw' when you need every individual price point
 ```
 
-### Get Diesel Prices (New in v0.4.0)
+### Get Diesel Prices
 
 #### Get State Average Diesel Price
 
@@ -226,7 +226,7 @@ console.log(
 
 **Note:** Station-level diesel prices are available on paid tiers (Exploration and above). State averages are free.
 
-### Price Alerts (New in v0.5.0)
+### Price Alerts
 
 #### Create a Price Alert
 
@@ -328,7 +328,7 @@ When an alert triggers, a POST request is sent to your webhook URL with:
 - Condition value: Must be between $0.01 and $1,000,000
 - Webhook URL: Must use HTTPS protocol
 
-### Commodities Metadata (New in v0.7.0)
+### Commodities Metadata
 
 ```typescript
 // List all available commodities
@@ -345,7 +345,7 @@ const categories = await client.commodities.categories();
 console.log(`Oil category: ${categories.oil.commodities.length} commodities`);
 ```
 
-### Futures Contracts (New in v0.7.0)
+### Futures Contracts
 
 ```typescript
 // Get latest futures price
@@ -495,7 +495,7 @@ const futures = await client.raw.get("/v1/futures/CL.1");
 console.log(futures.status, futures.data);
 ```
 
-### Storage Levels (New in v0.7.0)
+### Storage Levels
 
 ```typescript
 // Get total US crude storage
@@ -511,7 +511,7 @@ const spr = await client.storage.spr();
 console.log(`SPR: ${spr.level} ${spr.unit}`);
 ```
 
-### Rig Counts (New in v0.7.0)
+### Rig Counts
 
 ```typescript
 // Get latest Baker Hughes rig count
@@ -525,7 +525,7 @@ console.log(`Week-over-week: ${summary.week_change}`);
 console.log(`Year-over-year: ${summary.year_change}`);
 ```
 
-### Analytics (New in v0.7.0)
+### Analytics
 
 ```typescript
 // Get performance metrics
@@ -541,7 +541,7 @@ const corr = await client.analytics.correlation("WTI_USD", "BRENT_CRUDE_USD", 90
 console.log(`Correlation: ${corr.correlation} (${corr.strength})`);
 ```
 
-### Drilling Intelligence (New in v0.7.0)
+### Drilling Intelligence
 
 ```typescript
 // Get latest drilling activity
@@ -555,7 +555,7 @@ console.log(`Permian rigs: ${permian.active_rigs}`);
 console.log(`DUC wells: ${permian.duc_wells}`);
 ```
 
-### Energy Intelligence (New in v0.7.0)
+### Energy Intelligence
 
 Access comprehensive energy market intelligence from EIA, Baker Hughes, and FracFocus.
 
@@ -579,7 +579,7 @@ timeline.events.forEach((e) => {
 });
 ```
 
-### Webhooks (New in v0.7.0)
+### Webhooks
 
 ```typescript
 // Create a webhook
@@ -601,25 +601,32 @@ webhooks.forEach((wh) => {
 });
 ```
 
-### Bunker Fuels (New in v0.7.0)
+### Bunker Fuels
 
 ```typescript
-// Get bunker fuel prices at all ports
-const bunkerPrices = await client.bunkerFuels.all();
-console.log(`${bunkerPrices.length} port prices available`);
+// Get bunker fuel prices at all ports (Professional plan or above),
+// keyed by port code
+const all = await client.bunkerFuels.all();
+console.log(`${Object.keys(all.ports).length} ports available`);
 
-// Get prices at specific port
-const singapore = await client.bunkerFuels.port("SGSIN");
-console.log(`Singapore VLSFO: $${singapore.prices.VLSFO}/MT`);
+// Get prices at a specific port — `prices` is an ARRAY of per-grade entries
+const singapore = await client.bunkerFuels.port("SIN");
+const vlsfo = singapore.prices.find((p) => p.grade === "VLSFO");
+console.log(`${singapore.port.name} VLSFO: $${vlsfo?.price}/MT`);
 
-// Compare prices across ports
-const comparison = await client.bunkerFuels.compare("VLSFO");
-comparison.ports.forEach((p) => {
-  console.log(`${p.port_name}: $${p.price}/MT (rank ${p.rank})`);
-});
+// Compare prices across ports (2-10 port codes)
+const comparison = await client.bunkerFuels.compare(["SIN", "RTM", "HOU"]);
+for (const [code, entry] of Object.entries(comparison.comparison)) {
+  const p = entry.prices.find((p) => p.grade === "VLSFO");
+  console.log(`${entry.port.name}: $${p?.price}/MT`);
+}
 ```
 
-### Forecasts (New in v0.7.0)
+> **Changed in v1.0.0:** the port response's `prices` field is an array of
+> per-grade entries (matching the live API), not a `{ VLSFO: number }` keyed
+> object. See [#29](https://github.com/OilpriceAPI/oilpriceapi-node/issues/29).
+
+### Forecasts
 
 ```typescript
 // Get monthly forecasts
@@ -640,7 +647,7 @@ const wtiQ2 = await client.forecasts.get({
 console.log(`WTI Q2 forecast: $${wtiQ2.forecast_price}`);
 ```
 
-### Data Sources (New in v0.7.0)
+### Data Sources
 
 Manage custom data source integrations for Bring Your Own Source (BYOS).
 
@@ -727,7 +734,7 @@ process.on("SIGINT", () => {
 
 See [`examples/streaming.ts`](./examples/streaming.ts) for a complete runnable example.
 
-### Market Brief (New in v0.10.0)
+### Market Brief
 
 A single call returns a structured, multi-commodity market summary — latest
 price, 24h change, freshness, and a 1-month forecast band per commodity — with
@@ -756,7 +763,7 @@ const withNarrative = await client.getMarketBrief(["BRENT_CRUDE_USD"], {
 console.log(withNarrative.narrative);
 ```
 
-### Agent Subscriptions / Watches (New in v0.10.0)
+### Agent Subscriptions / Watches
 
 Persistent server-side "watches" evaluate a set of commodity codes on a recurring
 interval and emit events you can poll for — ideal for autonomous agents that want

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi",
-  "version": "0.10.0",
+  "version": "1.0.0",
   "description": "Official Node.js SDK for Oil Price API - Real-time and historical oil & commodity prices",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,12 +93,21 @@ export type {
   RigCountSummary,
 } from "./resources/rig-counts.js";
 export type {
+  BunkerPortInfo,
   BunkerFuelPrice,
+  BunkerSpreadValue,
+  BunkerResponseMetadata,
+  PortPricesEntry,
+  AllBunkerPrices,
   PortBunkerPrices,
   PortPriceComparison,
+  PortToPortSpreadDetail,
   BunkerFuelSpreads,
   HistoricalBunkerPrice,
+  HistoricalBunkerData,
+  BunkerExportRow,
   HistoricalBunkerOptions,
+  BunkerSpreadOptions,
 } from "./resources/bunker-fuels.js";
 export type {
   PerformanceMetrics,

--- a/src/resources/bunker-fuels.ts
+++ b/src/resources/bunker-fuels.ts
@@ -3,123 +3,216 @@
  *
  * Access bunker fuel prices at major ports worldwide, including VLSFO, MGO,
  * and IFO380. Compare prices across ports and track historical trends.
+ *
+ * Response shapes below mirror the backend `V1::BunkerFuelsController`
+ * exactly (after the client strips the outer `{ data: ... }` envelope).
  */
 
 import type { OilPriceAPI } from "../client.js";
 import { ValidationError } from "../errors.js";
 
 /**
- * Bunker fuel price data
+ * Port information block returned on every port-scoped response
+ */
+export interface BunkerPortInfo {
+  /** Port code (e.g., "SIN", "RTM") */
+  code: string;
+  /** Port name (e.g., "Singapore") */
+  name: string;
+  /** Country */
+  country: string;
+  /** IANA timezone (e.g., "Asia/Singapore") */
+  timezone?: string | null;
+  /** Rank by bunkering volume (1 = largest) */
+  volume_rank?: number | null;
+}
+
+/**
+ * A single fuel-grade price entry at a port.
+ *
+ * NOTE (v1.0.0): the API returns port prices as an ARRAY of these entries —
+ * one per fuel grade — not as a `{ VLSFO: number }` keyed object as pre-1.0
+ * SDK types claimed. See https://github.com/OilpriceAPI/oilpriceapi-node/issues/29
  */
 export interface BunkerFuelPrice {
-  /** Port code */
-  port: string;
-  /** Port name */
-  port_name?: string;
-  /** Fuel type (e.g., "VLSFO", "MGO", "IFO380") */
-  fuel_type: string;
+  /** Fuel grade code (e.g., "VLSFO", "MGO", "HSFO", "IFO380") */
+  grade: string;
+  /** Human-readable grade name (e.g., "Very Low Sulfur Fuel Oil") */
+  grade_name: string;
   /** Price per metric ton */
   price: number;
   /** Currency code (typically "USD") */
   currency: string;
   /** Unit (typically "MT" for metric ton) */
   unit: string;
-  /** ISO timestamp when price was recorded */
-  timestamp: string;
-  /** Price change from previous day */
-  change?: number;
-  /** Additional metadata */
-  metadata?: Record<string, unknown>;
+  /** Absolute price change vs ~24h ago; null when no prior data */
+  change_24h: number | null;
+  /** Percent price change vs ~24h ago; null when no prior data */
+  change_pct_24h: number | null;
+  /** Number of suppliers quoting at this port, when known */
+  supplier_count?: number | null;
+  /** Availability indicator, when known */
+  availability?: string | null;
+  /** ISO timestamp when the price was recorded */
+  last_updated: string;
 }
 
 /**
- * Port-specific bunker fuel prices
+ * A spread figure between two prices (port-to-port or grade-to-grade)
+ */
+export interface BunkerSpreadValue {
+  /** Spread in USD/MT */
+  value: number;
+  /** Spread as a percentage of the base price */
+  percentage: number;
+  /** Estimated daily scrubber benefit (VLSFO/HSFO spread only) */
+  scrubber_benefit_daily?: number;
+}
+
+/**
+ * Response metadata block attached to bunker fuel responses
+ */
+export interface BunkerResponseMetadata {
+  request_id: string;
+  /** ISO timestamp when the response was generated */
+  timestamp: string;
+  /** Server cache TTL in seconds */
+  cache_ttl: number;
+  data_source: string;
+  currency: string;
+  unit: string;
+  /** Additional fields (e.g., `port_count` on the all-ports endpoint) */
+  [key: string]: unknown;
+}
+
+/**
+ * Port entry in the all-ports / comparison responses
+ */
+export interface PortPricesEntry {
+  /** Port information */
+  port: BunkerPortInfo;
+  /** Price entries, one per fuel grade */
+  prices: BunkerFuelPrice[];
+}
+
+/**
+ * All-ports bunker prices response (`GET /v1/bunker-fuels/all`)
+ */
+export interface AllBunkerPrices {
+  /** Port data keyed by port code (e.g., `ports.SIN.prices`) */
+  ports: Record<string, PortPricesEntry>;
+  metadata: BunkerResponseMetadata;
+}
+
+/**
+ * Port-specific bunker fuel prices (`GET /v1/bunker-fuels/ports/:port_code`)
+ *
+ * BREAKING (v1.0.0): `prices` is an ARRAY of {@link BunkerFuelPrice} entries
+ * (one per fuel grade), not a `{ VLSFO: number }` keyed object. `port` is an
+ * info object, not a string. (#29)
  */
 export interface PortBunkerPrices {
-  /** Port code */
-  port: string;
-  /** Port name */
-  port_name: string;
-  /** Geographic region */
-  region?: string;
-  /** ISO timestamp */
-  timestamp: string;
-  /** Fuel prices by type */
-  prices: {
-    /** VLSFO price */
-    VLSFO?: number;
-    /** MGO price */
-    MGO?: number;
-    /** IFO380 price */
-    IFO380?: number;
-    /** Other fuel types */
-    [fuelType: string]: number | undefined;
-  };
-  /** Currency code */
-  currency: string;
-  /** Unit of measurement */
-  unit: string;
+  /** Port information */
+  port: BunkerPortInfo;
+  /** Price entries, one per fuel grade available at the port */
+  prices: BunkerFuelPrice[];
+  /**
+   * Spreads: keys like `to_rtm` map to per-grade spread objects
+   * (`{ vlsfo: { value, percentage } }`); `vlsfo_hsfo_spread` maps directly
+   * to a {@link BunkerSpreadValue}.
+   */
+  spreads: Record<string, BunkerSpreadValue | Record<string, BunkerSpreadValue>>;
+  metadata: BunkerResponseMetadata;
 }
 
 /**
- * Price comparison between ports
+ * Price comparison between ports (`GET /v1/bunker-fuels/compare`)
  */
 export interface PortPriceComparison {
-  /** Fuel type being compared */
-  fuel_type: string;
-  /** ISO timestamp */
-  timestamp: string;
-  /** Array of port prices */
-  ports: Array<{
-    /** Port code */
-    port: string;
-    /** Port name */
-    port_name: string;
-    /** Price */
-    price: number;
-    /** Rank (1 = cheapest) */
-    rank?: number;
-  }>;
-  /** Currency code */
-  currency: string;
-  /** Unit of measurement */
-  unit: string;
+  /** Per-port data keyed by port code */
+  comparison: Record<string, PortPricesEntry>;
+  /** Cross-port spreads keyed by pair (e.g., `SIN_RTM`) */
+  spreads: Record<string, unknown>;
+  metadata: BunkerResponseMetadata;
 }
 
 /**
- * Bunker fuel price spreads
+ * Port-to-port spread detail when a specific fuel grade was requested
+ */
+export interface PortToPortSpreadDetail {
+  value: number;
+  percentage: number;
+  from_price?: number;
+  to_price?: number;
+  arbitrage_opportunity?: string;
+}
+
+/**
+ * Port-to-port spread response (`GET /v1/bunker-fuels/spreads/ports`)
  */
 export interface BunkerFuelSpreads {
-  /** ISO timestamp */
-  timestamp: string;
-  /** Spreads between fuel grades */
-  spreads: Array<{
-    /** High-grade fuel */
-    fuel1: string;
-    /** Low-grade fuel */
-    fuel2: string;
-    /** Average spread across ports */
-    average_spread: number;
-    /** Spread range */
-    min_spread: number;
-    max_spread: number;
-  }>;
-  /** Currency code */
-  currency: string;
+  from_port: BunkerPortInfo;
+  to_port: BunkerPortInfo;
+  /** The requested fuel grade, or null when comparing all grades */
+  fuel_grade: string | null;
+  /**
+   * With a `grade` param: a single {@link PortToPortSpreadDetail}.
+   * Without: spread per grade keyed by lowercase grade code
+   * (e.g., `{ vlsfo: { value, percentage } }`). Empty object when either
+   * port has no price data.
+   */
+  spreads: PortToPortSpreadDetail | Record<string, BunkerSpreadValue>;
+  metadata: BunkerResponseMetadata;
 }
 
 /**
- * Historical bunker fuel price data
+ * Aggregated historical price point
  */
 export interface HistoricalBunkerPrice {
-  /** Date in YYYY-MM-DD format */
-  date: string;
-  /** Price */
-  price: number;
-  /** Currency code */
-  currency: string;
-  /** Unit of measurement */
-  unit: string;
+  /** ISO timestamp of the aggregation bucket */
+  timestamp: string;
+  /** Commodity code (e.g., "VLSFO_SIN") */
+  code: string;
+  /** Average price over the interval */
+  average_value: number;
+  /** Aggregation interval (e.g., "daily") */
+  interval_type: string;
+  /** Present when served from pre-computed daily summaries */
+  min_value?: number;
+  max_value?: number;
+  open_value?: number;
+  close_value?: number;
+  sample_count?: number;
+}
+
+/**
+ * Historical bunker prices response (`GET /v1/bunker-fuels/historical/:port_code`)
+ */
+export interface HistoricalBunkerData {
+  /** Port information */
+  port: BunkerPortInfo;
+  /** Aggregated price points, most recent first (all grades for the port) */
+  historical_data: HistoricalBunkerPrice[];
+  /** The resolved query period */
+  period: {
+    from: string;
+    to: string;
+    interval: string;
+  };
+  metadata: BunkerResponseMetadata;
+}
+
+/**
+ * A row in the JSON export (`GET /v1/bunker-fuels/export?format=json`)
+ */
+export interface BunkerExportRow {
+  timestamp: string;
+  port_code: string;
+  port_name: string;
+  fuel_grade: string;
+  price_usd_mt: number;
+  supplier_count?: number | null;
+  availability?: string | null;
 }
 
 /**
@@ -161,12 +254,10 @@ export interface BunkerSpreadOptions {
  *
  * const client = new OilPriceAPI({ apiKey: 'your_key' });
  *
- * // Get all bunker fuel prices
- * const prices = await client.bunkerFuels.all();
- *
- * // Get prices for specific port
+ * // Get prices for a specific port — prices is an ARRAY of grade entries
  * const singapore = await client.bunkerFuels.port('SIN');
- * console.log(`Singapore VLSFO: $${singapore.prices.VLSFO}/MT`);
+ * const vlsfo = singapore.prices.find(p => p.grade === 'VLSFO');
+ * console.log(`Singapore VLSFO: $${vlsfo?.price}/MT`);
  *
  * // Compare prices across ports
  * const comparison = await client.bunkerFuels.compare(['SIN', 'RTM', 'HOU']);
@@ -178,35 +269,34 @@ export class BunkerFuelsResource {
   /**
    * Get all current bunker fuel prices
    *
-   * Returns prices for all tracked ports and fuel types.
+   * Returns prices for all tracked ports, keyed by port code. Requires a
+   * Professional plan or above.
    *
-   * @returns Array of bunker fuel prices
+   * @returns All-ports bunker prices
    *
    * @throws {OilPriceAPIError} If API request fails
    * @throws {AuthenticationError} If API key is invalid
    *
    * @example
    * ```typescript
-   * const prices = await client.bunkerFuels.all();
-   * prices.forEach(price => {
-   *   console.log(`${price.port_name} ${price.fuel_type}: $${price.price}/${price.unit}`);
-   * });
+   * const all = await client.bunkerFuels.all();
+   * for (const [code, entry] of Object.entries(all.ports)) {
+   *   entry.prices.forEach(p => {
+   *     console.log(`${entry.port.name} ${p.grade}: $${p.price}/${p.unit}`);
+   *   });
+   * }
    * ```
    */
-  async all(): Promise<BunkerFuelPrice[]> {
+  async all(): Promise<AllBunkerPrices> {
     // Route is GET /v1/bunker-fuels/all (the bare /v1/bunker-fuels has no route).
-    const response = await this.client["request"]<
-      BunkerFuelPrice[] | { prices: BunkerFuelPrice[] }
-    >("/v1/bunker-fuels/all", {});
-
-    return Array.isArray(response) ? response : response.prices;
+    return this.client["request"]<AllBunkerPrices>("/v1/bunker-fuels/all", {});
   }
 
   /**
    * Get bunker fuel prices for a specific port
    *
    * @param code - Port code (e.g., "SIN" for Singapore, "RTM" for Rotterdam)
-   * @returns Port-specific prices across fuel types
+   * @returns Port-specific prices — `prices` is an array of per-grade entries
    *
    * @throws {NotFoundError} If port code not found
    * @throws {OilPriceAPIError} If API request fails
@@ -214,9 +304,10 @@ export class BunkerFuelsResource {
    * @example
    * ```typescript
    * const singapore = await client.bunkerFuels.port('SIN');
-   * console.log(`Singapore Bunker Prices (${singapore.timestamp}):`);
-   * console.log(`VLSFO: $${singapore.prices.VLSFO}/${singapore.unit}`);
-   * console.log(`MGO: $${singapore.prices.MGO}/${singapore.unit}`);
+   * console.log(`${singapore.port.name} bunker prices:`);
+   * singapore.prices.forEach(p => {
+   *   console.log(`${p.grade}: $${p.price}/${p.unit} (${p.change_24h ?? 'n/a'} 24h)`);
+   * });
    * ```
    */
   async port(code: string): Promise<PortBunkerPrices> {
@@ -230,19 +321,19 @@ export class BunkerFuelsResource {
   /**
    * Compare prices across multiple ports
    *
-   * @param ports - Array of port codes to compare
-   * @returns Price comparison data
+   * @param ports - Array of port codes to compare (2-10 ports)
+   * @returns Per-port price data keyed by port code, plus cross-port spreads
    *
    * @throws {OilPriceAPIError} If API request fails
    *
    * @example
    * ```typescript
-   * const comparison = await client.bunkerFuels.compare(['SIN', 'RTM', 'HOU', 'FUJ']);
+   * const comparison = await client.bunkerFuels.compare(['SIN', 'RTM', 'HOU']);
    *
-   * console.log(`Comparing ${comparison.fuel_type} prices:`);
-   * comparison.ports.forEach((port, index) => {
-   *   console.log(`${index + 1}. ${port.port_name}: $${port.price}`);
-   * });
+   * for (const [code, entry] of Object.entries(comparison.comparison)) {
+   *   const vlsfo = entry.prices.find(p => p.grade === 'VLSFO');
+   *   console.log(`${entry.port.name}: $${vlsfo?.price}/MT`);
+   * }
    * ```
    */
   async compare(ports: string[]): Promise<PortPriceComparison> {
@@ -289,20 +380,16 @@ export class BunkerFuelsResource {
   /**
    * Get historical bunker fuel prices
    *
-   * @param port - Port code (e.g., "SIN", "RTM")
-   * @param fuelType - Fuel type (e.g., "VLSFO", "MGO", "IFO380")
-   * @param options - Date range filters
-   * @returns Array of historical prices
-   *
-   * @throws {NotFoundError} If port or fuel type not found
-   * @throws {OilPriceAPIError} If API request fails
-   *
    * The history endpoint is keyed by port in the PATH (`/historical/:port_code`)
    * and returns all grades for that port; it does not filter by a single fuel
    * type. It reads `from` / `to` / `interval` query params.
    *
    * @param port - Port code (e.g., "SIN", "RTM") — used as a path segment
    * @param options - `{ startDate, endDate, interval }`
+   * @returns Historical price data with port info and the resolved period
+   *
+   * @throws {NotFoundError} If port not found
+   * @throws {OilPriceAPIError} If API request fails
    *
    * @example
    * ```typescript
@@ -311,15 +398,12 @@ export class BunkerFuelsResource {
    *   endDate: '2024-12-31'
    * });
    *
-   * history.forEach(point => {
-   *   console.log(`${point.date}: $${point.price}/${point.unit}`);
+   * history.historical_data.forEach(point => {
+   *   console.log(`${point.timestamp} ${point.code}: ${point.average_value}`);
    * });
    * ```
    */
-  async historical(
-    port: string,
-    options?: HistoricalBunkerOptions,
-  ): Promise<HistoricalBunkerPrice[]> {
+  async historical(port: string, options?: HistoricalBunkerOptions): Promise<HistoricalBunkerData> {
     if (!port || typeof port !== "string") {
       throw new ValidationError("Port code must be a non-empty string");
     }
@@ -330,36 +414,34 @@ export class BunkerFuelsResource {
     if (options?.interval) params.interval = options.interval;
 
     // Port code is a PATH segment: GET /v1/bunker-fuels/historical/:port_code
-    const response = await this.client["request"]<
-      HistoricalBunkerPrice[] | { data: HistoricalBunkerPrice[] }
-    >(`/v1/bunker-fuels/historical/${port}`, params);
-
-    return Array.isArray(response) ? response : response.data;
+    return this.client["request"]<HistoricalBunkerData>(
+      `/v1/bunker-fuels/historical/${port}`,
+      params,
+    );
   }
 
   /**
    * Export bunker fuel data
    *
-   * Export bunker fuel prices in specified format (CSV, JSON, Excel).
+   * Export bunker fuel prices in the specified format. JSON (the default)
+   * returns an array of {@link BunkerExportRow}; CSV is served as a file
+   * download and is better fetched directly over HTTP.
    *
-   * @param format - Export format (default: "csv")
-   * @returns Export data or download URL
+   * @param format - Export format (default: "json")
+   * @returns Export rows (JSON format)
    *
    * @throws {OilPriceAPIError} If API request fails
    *
    * @example
    * ```typescript
-   * // Export as CSV
-   * const csvData = await client.bunkerFuels.export('csv');
-   *
-   * // Export as JSON
-   * const jsonData = await client.bunkerFuels.export('json');
+   * const rows = await client.bunkerFuels.export('json');
+   * console.log(`${rows.length} price rows exported`);
    * ```
    */
-  async export(format?: string): Promise<any> {
+  async export(format?: string): Promise<BunkerExportRow[]> {
     const params: Record<string, string> = {};
     if (format) params.format = format;
 
-    return this.client["request"]<any>("/v1/bunker-fuels/export", params);
+    return this.client["request"]<BunkerExportRow[]>("/v1/bunker-fuels/export", params);
   }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,7 +7,7 @@
  * - X-Client-Version header
  * - Package.json (should match)
  */
-export const SDK_VERSION = "0.10.0";
+export const SDK_VERSION = "1.0.0";
 
 /**
  * SDK identifier used in User-Agent and X-Api-Client headers

--- a/tests/resources/bunker-fuels.test.ts
+++ b/tests/resources/bunker-fuels.test.ts
@@ -1,6 +1,66 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { OilPriceAPI } from "../../src/client.js";
 
+/**
+ * Mock payloads mirror the backend V1::BunkerFuelsController responses AFTER
+ * the client strips the outer `{ data: ... }` envelope — i.e. what the
+ * private `request()` resolves to.
+ */
+
+const sinPortInfo = {
+  code: "SIN",
+  name: "Singapore",
+  country: "Singapore",
+  timezone: "Asia/Singapore",
+  volume_rank: 1,
+};
+
+const rtmPortInfo = {
+  code: "RTM",
+  name: "Rotterdam",
+  country: "Netherlands",
+  timezone: "Europe/Amsterdam",
+  volume_rank: 2,
+};
+
+// The API returns port prices as an ARRAY of per-grade entries (issue #29),
+// not a `{ VLSFO: number }` keyed object.
+const sinPriceEntries = [
+  {
+    grade: "VLSFO",
+    grade_name: "Very Low Sulfur Fuel Oil",
+    price: 650.5,
+    currency: "USD",
+    unit: "MT",
+    change_24h: -2.25,
+    change_pct_24h: -0.35,
+    supplier_count: 12,
+    availability: "Good",
+    last_updated: "2024-01-15T00:00:00Z",
+  },
+  {
+    grade: "MGO",
+    grade_name: "Marine Gas Oil",
+    price: 748.0,
+    currency: "USD",
+    unit: "MT",
+    change_24h: null,
+    change_pct_24h: null,
+    supplier_count: 8,
+    availability: "Good",
+    last_updated: "2024-01-15T00:00:00Z",
+  },
+];
+
+const metadata = {
+  request_id: "abc123def456",
+  timestamp: "2024-01-15T00:05:00Z",
+  cache_ttl: 300,
+  data_source: "Ship & Bunker",
+  currency: "USD",
+  unit: "metric_ton",
+};
+
 describe("BunkerFuelsResource", () => {
   let client: OilPriceAPI;
 
@@ -10,27 +70,47 @@ describe("BunkerFuelsResource", () => {
   });
 
   describe("port()", () => {
-    it("should fetch bunker prices for a port", async () => {
+    it("should fetch bunker prices for a port with prices as an ARRAY of grade entries", async () => {
       const mockData = {
-        port: "SIN",
-        port_name: "Singapore",
-        timestamp: "2024-01-15T00:00:00Z",
-        prices: {
-          VLSFO: 650,
-          MGO: 750,
+        port: sinPortInfo,
+        prices: sinPriceEntries,
+        spreads: {
+          to_rtm: { vlsfo: { value: 29.5, percentage: 4.54 } },
+          vlsfo_hsfo_spread: {
+            value: 85.0,
+            percentage: 15.03,
+            scrubber_benefit_daily: 2125.0,
+          },
         },
-        currency: "USD",
-        unit: "MT",
+        metadata,
       };
 
-      const requestSpy = vi
-        .spyOn(client as any, "request")
-        .mockResolvedValue(mockData);
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
 
       const result = await client.bunkerFuels.port("SIN");
 
       expect(requestSpy).toHaveBeenCalledWith("/v1/bunker-fuels/ports/SIN", {});
-      expect(result.port).toBe("SIN");
+
+      // port is an info object, not a string
+      expect(result.port.code).toBe("SIN");
+      expect(result.port.name).toBe("Singapore");
+
+      // prices is an array (the #29 fix)
+      expect(Array.isArray(result.prices)).toBe(true);
+      expect(result.prices).toHaveLength(2);
+
+      const vlsfo = result.prices.find((p) => p.grade === "VLSFO");
+      expect(vlsfo?.price).toBe(650.5);
+      expect(vlsfo?.grade_name).toBe("Very Low Sulfur Fuel Oil");
+      expect(vlsfo?.unit).toBe("MT");
+      expect(vlsfo?.change_24h).toBe(-2.25);
+
+      // change fields are null when the API has no prior-day data
+      const mgo = result.prices.find((p) => p.grade === "MGO");
+      expect(mgo?.change_24h).toBeNull();
+      expect(mgo?.change_pct_24h).toBeNull();
+
+      expect(result.metadata.cache_ttl).toBe(300);
     });
 
     it("should throw error for empty port code", async () => {
@@ -40,29 +120,168 @@ describe("BunkerFuelsResource", () => {
     });
   });
 
-  describe("compare()", () => {
-    it("should compare prices across ports", async () => {
+  describe("all()", () => {
+    it("should return ports keyed by port code, each with an array of grade prices", async () => {
       const mockData = {
-        fuel_type: "VLSFO",
-        timestamp: "2024-01-15T00:00:00Z",
-        ports: [
-          { port: "SIN", port_name: "Singapore", price: 650, rank: 1 },
-          { port: "RTM", port_name: "Rotterdam", price: 680, rank: 2 },
-        ],
-        currency: "USD",
-        unit: "MT",
+        ports: {
+          SIN: { port: sinPortInfo, prices: sinPriceEntries },
+          RTM: { port: rtmPortInfo, prices: [{ ...sinPriceEntries[0], price: 680.0 }] },
+        },
+        metadata: { ...metadata, port_count: 2 },
       };
 
-      const requestSpy = vi
-        .spyOn(client as any, "request")
-        .mockResolvedValue(mockData);
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
+
+      const result = await client.bunkerFuels.all();
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/bunker-fuels/all", {});
+      expect(Object.keys(result.ports)).toEqual(["SIN", "RTM"]);
+      expect(Array.isArray(result.ports.SIN.prices)).toBe(true);
+      expect(result.ports.SIN.prices[0].grade).toBe("VLSFO");
+      expect(result.ports.RTM.port.name).toBe("Rotterdam");
+    });
+  });
+
+  describe("compare()", () => {
+    it("should compare prices across ports (comparison keyed by port code)", async () => {
+      const mockData = {
+        comparison: {
+          SIN: { port: sinPortInfo, prices: sinPriceEntries },
+          RTM: { port: rtmPortInfo, prices: [{ ...sinPriceEntries[0], price: 680.0 }] },
+        },
+        spreads: {
+          SIN_RTM: { vlsfo: { value: 29.5, percentage: 4.54 } },
+        },
+        metadata,
+      };
+
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
 
       const result = await client.bunkerFuels.compare(["SIN", "RTM"]);
 
       expect(requestSpy).toHaveBeenCalledWith("/v1/bunker-fuels/compare", {
         ports: "SIN,RTM",
       });
-      expect(result.ports).toHaveLength(2);
+      expect(Object.keys(result.comparison)).toHaveLength(2);
+      expect(result.comparison.SIN.prices[0].price).toBe(650.5);
+      expect(result.comparison.RTM.prices[0].price).toBe(680.0);
+    });
+
+    it("should throw error for empty ports array", async () => {
+      await expect(client.bunkerFuels.compare([])).rejects.toThrow(
+        "Ports must be a non-empty array of port codes",
+      );
+    });
+  });
+
+  describe("spreads()", () => {
+    it("should fetch a graded port-to-port spread", async () => {
+      const mockData = {
+        from_port: sinPortInfo,
+        to_port: rtmPortInfo,
+        fuel_grade: "VLSFO",
+        spreads: {
+          value: 29.5,
+          percentage: 4.54,
+          from_price: 650.5,
+          to_price: 680.0,
+          arbitrage_opportunity: "Yes (>$29.5/MT)",
+        },
+        metadata,
+      };
+
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
+
+      const result = await client.bunkerFuels.spreads({
+        from: "SIN",
+        to: "RTM",
+        grade: "VLSFO",
+      });
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/bunker-fuels/spreads/ports", {
+        from: "SIN",
+        to: "RTM",
+        grade: "VLSFO",
+      });
+      expect(result.from_port.code).toBe("SIN");
+      expect(result.fuel_grade).toBe("VLSFO");
+      expect((result.spreads as { value: number }).value).toBe(29.5);
+    });
+
+    it("should throw when from/to missing", async () => {
+      await expect(client.bunkerFuels.spreads({ from: "SIN" } as any)).rejects.toThrow(
+        "Both 'from' and 'to' port codes are required",
+      );
+    });
+  });
+
+  describe("historical()", () => {
+    it("should return port info, historical_data array and period", async () => {
+      const mockData = {
+        port: sinPortInfo,
+        historical_data: [
+          {
+            timestamp: "2024-01-15T00:00:00Z",
+            code: "VLSFO_SIN",
+            average_value: 65050.0,
+            interval_type: "daily",
+          },
+          {
+            timestamp: "2024-01-14T00:00:00Z",
+            code: "VLSFO_SIN",
+            average_value: 65275.0,
+            interval_type: "daily",
+          },
+        ],
+        period: { from: "2024-01-01T00:00:00Z", to: "2024-01-15T00:00:00Z", interval: "daily" },
+        metadata,
+      };
+
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
+
+      const result = await client.bunkerFuels.historical("SIN", {
+        startDate: "2024-01-01",
+        endDate: "2024-01-15",
+      });
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/bunker-fuels/historical/SIN", {
+        from: "2024-01-01",
+        to: "2024-01-15",
+      });
+      expect(result.port.code).toBe("SIN");
+      expect(result.historical_data).toHaveLength(2);
+      expect(result.historical_data[0].code).toBe("VLSFO_SIN");
+      expect(result.period.interval).toBe("daily");
+    });
+
+    it("should throw error for empty port code", async () => {
+      await expect(client.bunkerFuels.historical("")).rejects.toThrow(
+        "Port code must be a non-empty string",
+      );
+    });
+  });
+
+  describe("export()", () => {
+    it("should return an array of export rows", async () => {
+      const mockData = [
+        {
+          timestamp: "2024-01-15T00:00:00Z",
+          port_code: "SIN",
+          port_name: "Singapore",
+          fuel_grade: "VLSFO",
+          price_usd_mt: 650.5,
+          supplier_count: 12,
+          availability: "Good",
+        },
+      ];
+
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockData);
+
+      const result = await client.bunkerFuels.export("json");
+
+      expect(requestSpy).toHaveBeenCalledWith("/v1/bunker-fuels/export", { format: "json" });
+      expect(result).toHaveLength(1);
+      expect(result[0].price_usd_mt).toBe(650.5);
     });
   });
 });


### PR DESCRIPTION
## Summary

Cuts **v1.0.0** — the first stable release (#26) — and fixes the bunker port response types (#29).

Closes #29. Closes #26 (the quick-start half already landed in #28; this delivers the 1.0.0 versioning half).

### Bunker type fix (#29) — Breaking

Verified against the backend `V1::BunkerFuelsController` (oilpriceapi-api): the port endpoint returns

```json
{ "data": {
    "port":     { "code": "SIN", "name": "Singapore", "country": "...", "timezone": "...", "volume_rank": 1 },
    "prices":   [ { "grade": "VLSFO", "grade_name": "...", "price": 650.5, "currency": "USD", "unit": "MT",
                    "change_24h": -2.25, "change_pct_24h": -0.35, "supplier_count": 12,
                    "availability": "Good", "last_updated": "..." }, ... ],
    "spreads":  { "to_rtm": { "vlsfo": { "value": ..., "percentage": ... } },
                  "vlsfo_hsfo_spread": { "value": ..., "percentage": ..., "scrubber_benefit_daily": ... } },
    "metadata": { "request_id": "...", "timestamp": "...", "cache_ttl": 300, "data_source": "Ship & Bunker", ... }
} }
```

i.e. `prices` is an **array of per-grade entries** (one per fuel grade) and `port` is an info object — not the `{ prices: { VLSFO: number } }` keyed shape the pre-1.0 types claimed.

While fixing #29 against the controller, the audit showed the other bunker methods had the same class of mismatch — `all()` and `historical()` even returned `undefined` at runtime because they read `.prices`/`.data` off envelopes that never existed. All bunker response types are now modeled from the controller source:

- `all()` → `{ ports: Record<portCode, { port, prices[] }>, metadata }`
- `compare()` → `{ comparison: Record<portCode, { port, prices[] }>, spreads, metadata }`
- `spreads()` → `{ from_port, to_port, fuel_grade, spreads, metadata }`
- `historical()` → `{ port, historical_data[], period, metadata }`
- `export()` → `BunkerExportRow[]`

README bunker examples fixed too (`SIN` not `SGSIN` — the route constraint is `[A-Z]{3}`, and `compare()` takes a port-code array).

### v1.0.0 (#26)

- `package.json` + `SDK_VERSION` → 1.0.0
- CHANGELOG `## [1.0.0] - 2026-07-03` with the type fix under **Breaking** and a first-stable-release note
- README: stale `NEW in v0.x` markers removed

## Test evidence

- `npm test` → **429 passed | 1 skipped (430), 28 files, 0 failures**
- `npm run build` (tsc ESM + CJS) → clean; `npx tsc --noEmit` → clean
- `npx eslint src/` → 0 errors, 10 pre-existing warnings (main has 12 — this PR removes two)
- Prettier check on all touched files → clean

## Release procedure (after merge — Karl cuts this)

Publishing is driven by `.github/workflows/publish.yml`, which triggers on a **published GitHub Release** and publishes to npm via **OIDC trusted publishing** (no token needed; provenance automatic). After merging:

1. `git tag v1.0.0 && git push origin v1.0.0` (or create the tag in the UI)
2. Create a GitHub Release for `v1.0.0` (paste the CHANGELOG entry) and **publish** it
3. The workflow runs `tsc --noEmit`, tests, build, then `npm publish --provenance --access public`
4. Verify: `npm view oilpriceapi version` → `1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)