### PR TITLE
fix: drop venue-typed source enums; align examples with market_reporting (#4175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-07-10
+
+### Changed
+
+- Loosen `source` typing and align examples with the API's masked source labels: the response `source` now returns `market_reporting` for non-government series (government labels like `EIA`/`opec.org` are unchanged). The `FuturesPrice.source` field remains a free `string` (no venue enum); doc-comment and test fixture examples no longer use venue names such as `ICE`. See oilpriceapi-api#4175.
+
 ## [1.0.1] - 2026-07-03
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Official Node.js SDK for Oil Price API - Real-time and historical oil & commodity prices",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/src/resources/futures.ts
+++ b/src/resources/futures.ts
@@ -49,7 +49,7 @@ export interface FuturesContractMonth {
 export interface FuturesPrice {
   /** Commodity identifier (e.g. "BRENT_FUTURES"). */
   commodity?: string;
-  /** Data source (e.g. "ICE"). */
+  /** Data source label (e.g. "market_reporting", or a government label like "EIA"). */
   source?: string;
   /** ISO timestamp the data was last updated. */
   updated_at?: string;

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,7 +7,7 @@
  * - X-Client-Version header
  * - Package.json (should match)
  */
-export const SDK_VERSION = "1.0.1";
+export const SDK_VERSION = "1.0.2";
 
 /**
  * SDK identifier used in User-Agent and X-Api-Client headers

--- a/tests/resources/futures.test.ts
+++ b/tests/resources/futures.test.ts
@@ -25,7 +25,7 @@ describe("FuturesResource", () => {
       // structure in contracts[].
       const mockPrice: FuturesPrice = {
         commodity: "WTI_FUTURES",
-        source: "ICE",
+        source: "market_reporting",
         updated_at: "2024-01-15T10:00:00Z",
         settlement_date: "2024-01-15",
         front_month: {


### PR DESCRIPTION
## What & why

Part of the SDK-fleet sweep for oilpriceapi-api#4175. The API is switching masked source labels to `market_reporting` (government labels like `EIA`/`opec.org` unchanged). This aligns the Node/TypeScript SDK.

## Typing

No enum to loosen — `FuturesPrice.source` (and all `source` fields) are already `string`. So nothing breaks when the API starts returning `market_reporting`.

## Examples/fixtures fixed

- `src/resources/futures.ts`: doc comment `Data source (e.g. "ICE")` → `Data source label (e.g. "market_reporting", or a government label like "EIA")`.
- `tests/resources/futures.test.ts`: fixture `source: "ICE"` → `source: "market_reporting"`.

Left unchanged intentionally: `ice-brent`/`ice-wti` are **route path slugs** (`/v1/futures/{slug}`), not source labels — those belong to the futures route-alias work, not this issue. `types.ts` example `"oilprice.ft"` is not a venue.

## Version (unpublished)

- `1.0.1` → `1.0.2` in `package.json`, CHANGELOG entry added. **Not** published to npm.

## Test/build

- `npm run build` (tsc + cjs): passes.
- `npm test -- futures` (vitest): 64/64 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
