### PR TITLE
feat: well-production resource + tests; scrub committed API key (#32)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
       - name: TypeScript build check
         run: npx tsc --noEmit
 
+      - name: Check for hardcoded API keys
+        run: npm run check:secrets
+
       - name: ESLint
         run: npx eslint src/
 

--- a/README.md
+++ b/README.md
@@ -573,6 +573,40 @@ console.log(`Permian rigs: ${permian.active_rigs}`);
 console.log(`DUC wells: ${permian.duc_wells}`);
 ```
 
+### Well Production
+
+US oil & gas production data: national/state monthly aggregates (EIA), well-level production from state regulatory agencies, and permit-to-production cycle-time analytics. Requires the drilling-intelligence tier.
+
+> **Beta coverage caveat:** well-level production is only available for the states collected from regulatory agencies so far — this is **not** complete US well-level coverage. State-level aggregates (EIA) are the comprehensive layer. Check `summary().coverage` before assuming a state or well is covered.
+
+```typescript
+// National overview: latest rollup, top states, data sources, coverage
+const summary = await client.wellProduction.summary();
+console.log(summary.top_states[0]); // { state: 'TX', period: '2026-04', oil_bbl: ..., ... }
+console.log(summary.coverage?.well_level_states_with_data); // e.g. ['AK', 'ND', 'NM', 'PA', 'TX']
+
+// Latest state-level production (or a specific month)
+const states = await client.wellProduction.states({ period: "2026-04" });
+
+// Production history for one state
+const tx = await client.wellProduction.stateDetail("TX", { start_date: "2026-01-01" });
+tx.data.forEach((r) => console.log(`${r.period}: ${r.oil_bbl} bbl oil`));
+
+// Production history for one well (14-digit API number)
+const well = await client.wellProduction.wellDetail("42-477-31122-00-00");
+console.log(`${well.well_name} (${well.operator}): ${well.count} months`);
+
+// Top producing wells in a state
+const top = await client.wellProduction.topProducers({ state_code: "TX", limit: 10 });
+
+// Permit-to-production cycle times
+const cycle = await client.wellProduction.cycleTime({ state: "TX" });
+console.log(`Median: ${cycle.cycle_time_stats.median_days} days`);
+
+// Cycle-time cohort comparison (quarterly by default)
+const cohorts = await client.wellProduction.cycleTimeCohorts({ state: "TX" });
+```
+
 ### Energy Intelligence
 
 Access comprehensive energy market intelligence from EIA, Baker Hughes, and FracFocus.

--- a/example-commodities.ts
+++ b/example-commodities.ts
@@ -1,6 +1,11 @@
 import { OilPriceAPI } from './src/index.js';
 
-const API_KEY = '3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11';
+// Reads your API key from the OILPRICEAPI_KEY environment variable.
+const API_KEY = process.env.OILPRICEAPI_KEY;
+if (!API_KEY) {
+  console.error('Set OILPRICEAPI_KEY to run this example.');
+  process.exit(1);
+}
 
 async function testCommoditiesEndpoints() {
   const client = new OilPriceAPI({ apiKey: API_KEY, debug: true });

--- a/example-walk.ts
+++ b/example-walk.ts
@@ -1,12 +1,20 @@
 import { OilPriceAPI } from './src/index.js';
 
+// Reads your API key from the OILPRICEAPI_KEY environment variable.
+// Never commit real keys — use 'your-api-key-here' only as a placeholder.
+const API_KEY = process.env.OILPRICEAPI_KEY;
+if (!API_KEY) {
+  console.error('Set OILPRICEAPI_KEY to run this example.');
+  process.exit(1);
+}
+
 async function main() {
   console.log('Testing Oil Price API Node.js SDK v0.2.0 (Walk Phase)\n');
 
   // Test 1: Basic request with retries
   console.log('1. Testing basic request with retry logic...');
   const client = new OilPriceAPI({
-    apiKey: '3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11',
+    apiKey: API_KEY,
     retries: 3,
     retryDelay: 1000,
     retryStrategy: 'exponential',
@@ -19,7 +27,7 @@ async function main() {
   // Test 2: Debug mode
   console.log('2. Testing debug logging...');
   const debugClient = new OilPriceAPI({
-    apiKey: '3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11',
+    apiKey: API_KEY,
     debug: true
   });
 
@@ -29,7 +37,7 @@ async function main() {
   // Test 3: Different retry strategies
   console.log('3. Testing retry strategies...');
   const linearClient = new OilPriceAPI({
-    apiKey: '3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11',
+    apiKey: API_KEY,
     retryStrategy: 'linear',
     retries: 2
   });
@@ -43,7 +51,7 @@ async function main() {
   // Test 4: Custom timeout
   console.log('4. Testing custom timeout (5 seconds)...');
   const shortTimeoutClient = new OilPriceAPI({
-    apiKey: '3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11',
+    apiKey: API_KEY,
     timeout: 5000  // 5 seconds
   });
 

--- a/example.ts
+++ b/example.ts
@@ -1,9 +1,10 @@
 import { OilPriceAPI } from './src/index.js';
 
 async function main() {
-  // Initialize with admin API key for testing
+  // Reads your API key from the OILPRICEAPI_KEY environment variable.
+  // Get a key at https://www.oilpriceapi.com — never commit real keys.
   const client = new OilPriceAPI({
-    apiKey: '3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11'
+    apiKey: process.env.OILPRICEAPI_KEY
   });
 
   console.log('Testing Oil Price API Node.js SDK...\n');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "tsc && tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "check:secrets": "node scripts/check-no-hardcoded-api-keys.mjs",
     "lint": "eslint src/",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/qa_test.js
+++ b/qa_test.js
@@ -3,7 +3,13 @@
  */
 import { OilPriceAPI } from './dist/index.js';
 
-const API_KEY = process.env.OIL_PRICE_API_KEY || '3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11';
+// Live QA needs a real key — set OILPRICEAPI_KEY (or legacy OIL_PRICE_API_KEY).
+const API_KEY = process.env.OILPRICEAPI_KEY || process.env.OIL_PRICE_API_KEY;
+
+if (!API_KEY) {
+  console.log('SKIP: set OILPRICEAPI_KEY to run live QA tests.');
+  process.exit(0);
+}
 
 async function runQATests() {
   console.log('=== Node.js SDK v0.3.0 QA Tests ===\n');

--- a/scripts/check-no-hardcoded-api-keys.mjs
+++ b/scripts/check-no-hardcoded-api-keys.mjs
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const root = process.cwd();
+const scanPaths = [
+  "README.md",
+  "CHANGELOG.md",
+  "PUBLISH_GUIDE.md",
+  "docs",
+  "example.ts",
+  "example-walk.ts",
+  "example-commodities.ts",
+  "examples",
+  "qa_test.js",
+  "src",
+  "tests",
+];
+const textExtensions = new Set([
+  ".cjs",
+  ".cts",
+  ".js",
+  ".json",
+  ".md",
+  ".mjs",
+  ".mts",
+  ".ts",
+  ".txt",
+  ".yaml",
+  ".yml",
+]);
+const skippedDirs = new Set([".git", "coverage", "dist", "node_modules"]);
+const tokenPattern = /(?<![A-Fa-f0-9])[A-Fa-f0-9]{64}(?![A-Fa-f0-9])/g;
+
+function extensionFor(path) {
+  const index = path.lastIndexOf(".");
+  return index === -1 ? "" : path.slice(index);
+}
+
+function* walk(path) {
+  const stat = statSync(path);
+  if (stat.isFile()) {
+    if (textExtensions.has(extensionFor(path).toLowerCase())) {
+      yield path;
+    }
+    return;
+  }
+
+  for (const entry of readdirSync(path)) {
+    if (skippedDirs.has(entry)) {
+      continue;
+    }
+    yield* walk(join(path, entry));
+  }
+}
+
+const findings = [];
+
+for (const scanPath of scanPaths) {
+  const absolute = join(root, scanPath);
+  try {
+    for (const file of walk(absolute)) {
+      const lines = readFileSync(file, "utf8").split(/\r?\n/);
+      lines.forEach((line, index) => {
+        for (const match of line.matchAll(tokenPattern)) {
+          const tokenHash = createHash("sha256").update(match[0]).digest("hex").slice(0, 16);
+          findings.push(`${relative(root, file)}:${index + 1}: sha256:${tokenHash}`);
+        }
+      });
+    }
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+if (findings.length > 0) {
+  console.error("Hardcoded OilPriceAPI-shaped token(s) found:");
+  for (const finding of findings) {
+    console.error(finding);
+  }
+  process.exit(1);
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -42,6 +42,7 @@ import { IndicatorsResource } from "./resources/indicators.js";
 import { RawResource } from "./resources/raw.js";
 import { StreamingResource } from "./resources/streaming.js";
 import { SubscriptionsResource } from "./resources/subscriptions.js";
+import { WellProductionResource } from "./resources/well-production.js";
 
 /**
  * Raw HTTP response wrapper.
@@ -199,6 +200,15 @@ export class OilPriceAPI {
    */
   public readonly subscriptions: SubscriptionsResource;
 
+  /**
+   * Well production resource (US national/state/well-level oil & gas
+   * production plus permit-to-production cycle-time analytics).
+   *
+   * Requires the drilling-intelligence tier. Well-level coverage is beta —
+   * limited to states collected from regulatory agencies so far.
+   */
+  public readonly wellProduction: WellProductionResource;
+
   constructor(config: OilPriceAPIConfig = {}) {
     this.apiKey = config.apiKey || process.env.OILPRICEAPI_KEY || "";
     if (!this.apiKey) {
@@ -235,6 +245,7 @@ export class OilPriceAPI {
     this.raw = new RawResource(this);
     this.stream = new StreamingResource(this);
     this.subscriptions = new SubscriptionsResource(this);
+    this.wellProduction = new WellProductionResource(this);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,8 @@ export type {
   PermitsByOperator,
   PermitsByFormation,
   WellPermitSearchQuery,
+  LatestWellPermit,
+  WellPermitLatestResponse,
   FracFocusRecord,
   FracFocusSummary,
   DisclosuresByState,
@@ -200,6 +202,27 @@ export type {
   SubscriptionEventsOptions,
 } from "./resources/subscriptions.js";
 export { SubscriptionsResource, intervalToSeconds } from "./resources/subscriptions.js";
+export { WellProductionResource } from "./resources/well-production.js";
+export type {
+  WellProductionRecord,
+  StateProductionSummary,
+  WellProductionSummary,
+  StatesProductionResponse,
+  StateProductionDetail,
+  WellProductionDetail,
+  TopProducingWell,
+  TopProducersResponse,
+  StatesOptions,
+  StateDetailOptions,
+  TopProducersOptions,
+  CycleTimeStats,
+  CycleTimeWell,
+  CycleTimeAnalysis,
+  CycleTimeCohort,
+  CycleTimeCohortsResponse,
+  CycleTimeQuery,
+  CycleTimeCohortsQuery,
+} from "./resources/well-production.js";
 export type {
   WebhookEndpoint,
   CreateWebhookParams,

--- a/src/resources/ei/index.ts
+++ b/src/resources/ei/index.ts
@@ -204,6 +204,8 @@ export type {
   PermitsByOperator,
   PermitsByFormation,
   WellPermitSearchQuery,
+  LatestWellPermit,
+  WellPermitLatestResponse,
 } from "./well-permits.js";
 export type {
   FracFocusRecord,

--- a/src/resources/ei/well-permits.ts
+++ b/src/resources/ei/well-permits.ts
@@ -92,6 +92,84 @@ export interface PermitsByFormation {
 }
 
 /**
+ * Well permit record returned by the `latest` endpoint.
+ *
+ * The live `/v1/ei/well-permits/latest` endpoint returns richer, nested
+ * records than the flat {@link WellPermitRecord} shape used elsewhere.
+ */
+export interface LatestWellPermit {
+  /** 14-digit API well number */
+  api_number: string | null;
+  /** Two-letter state code */
+  state_code: string;
+  /** County name */
+  county: string | null;
+  /** Permit number */
+  permit_number: string | null;
+  /** Permit type (e.g., "new_drill") */
+  permit_type: string | null;
+  /** Permit status (e.g., "approved") */
+  permit_status: string | null;
+  /** Permit date (YYYY-MM-DD) */
+  permit_date: string | null;
+  /** Operator details */
+  operator: {
+    name: string | null;
+    name_normalized: string | null;
+    number: string | null;
+  };
+  /** Well details */
+  well: {
+    name: string | null;
+    number: string | null;
+    type: string | null;
+  };
+  /** Surface location */
+  location: {
+    latitude: string | null;
+    longitude: string | null;
+  };
+  /** Target formation/depth */
+  target: {
+    formation: string | null;
+    formation_normalized: string | null;
+    total_depth_proposed: number | null;
+  };
+  /** Source provenance */
+  provenance: {
+    source: string | null;
+    fetched_at: string | null;
+  };
+}
+
+/**
+ * Envelope returned by `GET /v1/ei/well-permits/latest`.
+ *
+ * The live API returns a collection plus a `meta` block (lookback window,
+ * covered states, per-state data-quality notes) — not a single record.
+ */
+export interface WellPermitLatestResponse {
+  /** Most recent permits across covered states */
+  well_permits: LatestWellPermit[];
+  /** Collection metadata */
+  meta?: {
+    /** Lookback window in days */
+    days?: number;
+    /** States included in the response */
+    states?: string[];
+    /** Max records returned */
+    limit?: number;
+    /** Records returned */
+    count?: number;
+    /** Snapshot timestamp */
+    as_of?: string;
+    /** Per-state data-quality notes */
+    data_quality?: Record<string, { date_coverage?: string; source?: string; note?: string }>;
+    [key: string]: unknown;
+  };
+}
+
+/**
  * Well permit search query.
  *
  * Maps to the parameters the `search` action actually reads. Note: `operator`
@@ -132,9 +210,11 @@ export interface WellPermitSearchQuery {
  * ```typescript
  * const client = new OilPriceAPI({ apiKey: 'your_key' });
  *
- * // Get latest permits
+ * // Get latest permits (collection + meta envelope)
  * const latest = await client.ei.wellPermits.latest();
- * console.log(`Permit: ${latest.permit_number} - ${latest.operator}`);
+ * latest.well_permits.forEach(p =>
+ *   console.log(`${p.permit_number}: ${p.operator.name} (${p.state_code})`)
+ * );
  *
  * // Get permits by state
  * const states = await client.ei.wellPermits.byState();
@@ -142,8 +222,8 @@ export interface WellPermitSearchQuery {
  *
  * // Search permits
  * const results = await client.ei.wellPermits.search({
- *   state: 'Texas',
- *   operator: 'ConocoPhillips'
+ *   states: 'TX,NM',
+ *   well_name: 'Eagle'
  * });
  * ```
  */
@@ -178,12 +258,16 @@ export class EIWellPermitsResource {
   }
 
   /**
-   * Get latest well permit
+   * Get the latest well permits across covered states.
    *
-   * @returns Latest well permit record
+   * Returns the API's collection envelope (`{ well_permits, meta }`), not a
+   * single record — the previous `WellPermitRecord` return type did not match
+   * the live API response (see OilpriceAPI/oilpriceapi-node#32).
+   *
+   * @returns Latest well permits with collection metadata
    */
-  async latest(): Promise<WellPermitRecord> {
-    return this.client["request"]<WellPermitRecord>("/v1/ei/well-permits/latest", {});
+  async latest(): Promise<WellPermitLatestResponse> {
+    return this.client["request"]<WellPermitLatestResponse>("/v1/ei/well-permits/latest", {});
   }
 
   /**

--- a/src/resources/well-production.ts
+++ b/src/resources/well-production.ts
@@ -1,0 +1,472 @@
+/**
+ * Well Production Resource
+ *
+ * Access US oil & gas well production data: national/state monthly aggregates
+ * (EIA API v2), well-level production from state regulatory agencies, and
+ * permit-to-production cycle-time analytics.
+ *
+ * Coverage note (beta): well-level production is only available for the states
+ * collected from regulatory agencies so far (see `summary().coverage`). This is
+ * NOT complete US well-level coverage — state aggregates (EIA) are the
+ * comprehensive layer.
+ */
+
+import type { OilPriceAPI } from "../client.js";
+import { ValidationError } from "../errors.js";
+
+/**
+ * Monthly production record (national, state, or well granularity)
+ */
+export interface WellProductionRecord {
+  /** Production month (YYYY-MM) */
+  period: string;
+  /** Oil production in barrels */
+  oil_bbl: number | null;
+  /** Gas production in thousand cubic feet */
+  gas_mcf: number | null;
+  /** Water production in barrels (well-level sources only) */
+  water_bbl: number | null;
+  /** Barrels of oil equivalent */
+  boe: number | null;
+  /** Days producing in the month (when reported by the source) */
+  days_producing: number | null;
+  /** Data source (e.g., "eia_api", "tx_rrc", "market_reporting") */
+  source: string;
+}
+
+/**
+ * State-level production summary row
+ */
+export interface StateProductionSummary {
+  /** Two-letter state code (e.g., "TX") */
+  state: string;
+  /** Production month (YYYY-MM) */
+  period: string;
+  /** Oil production in barrels */
+  oil_bbl: number | null;
+  /** Oil production in barrels per day (derived) */
+  oil_bpd: number | null;
+  /** Gas production in thousand cubic feet */
+  gas_mcf: number | null;
+  /** Barrels of oil equivalent */
+  boe: number | null;
+}
+
+/**
+ * National production overview (GET /v1/well-production)
+ */
+export interface WellProductionSummary {
+  /** Latest national monthly rollup (null when unavailable) */
+  national: WellProductionRecord | null;
+  /** Top producing states for the latest month */
+  top_states: StateProductionSummary[];
+  /** Description of where each data layer comes from */
+  data_sources?: {
+    state_aggregates?: string;
+    well_level?: string;
+    well_level_states?: string[];
+    national_rollup?: string;
+    [key: string]: unknown;
+  };
+  /** Coverage metadata — which states/periods have data */
+  coverage?: {
+    states_with_data?: string[];
+    well_level_states_with_data?: string[];
+    latest_period?: string | null;
+    total_records?: number;
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * State production listing (GET /v1/well-production/states)
+ */
+export interface StatesProductionResponse {
+  /** Month the listing covers (YYYY-MM) */
+  period: string | null;
+  /** Number of states returned */
+  count: number;
+  /** Per-state production rows, ordered by oil production */
+  states: StateProductionSummary[];
+}
+
+/**
+ * State production history (GET /v1/well-production/states/:code)
+ */
+export interface StateProductionDetail {
+  /** Two-letter state code */
+  state: string;
+  /** Requested date range */
+  period: { start: string; end: string };
+  /** Number of monthly records */
+  count: number;
+  /** Monthly production records, oldest first */
+  data: WellProductionRecord[];
+}
+
+/**
+ * Well production history (GET /v1/well-production/wells/:api)
+ */
+export interface WellProductionDetail {
+  /** 14-digit API well number */
+  api_number: string;
+  /** Operator name */
+  operator: string | null;
+  /** Well name */
+  well_name: string | null;
+  /** Two-letter state code */
+  state: string | null;
+  /** Number of monthly records */
+  count: number;
+  /** Monthly production records, oldest first */
+  data: WellProductionRecord[];
+}
+
+/**
+ * Top producing well row
+ */
+export interface TopProducingWell {
+  /** 14-digit API well number */
+  api_number: string;
+  /** Operator name */
+  operator: string | null;
+  /** Well name */
+  well_name: string | null;
+  /** Total oil over the period in barrels */
+  total_oil_bbl: number | null;
+  /** Total gas over the period in thousand cubic feet */
+  total_gas_mcf: number | null;
+  /** Number of months with production in the period */
+  months_producing: number | null;
+}
+
+/**
+ * Top producers listing (GET /v1/well-production/top-producers)
+ */
+export interface TopProducersResponse {
+  /** Two-letter state code the ranking covers */
+  state: string;
+  /** Date range used for the ranking */
+  period: { start: string; end: string };
+  /** Number of wells returned */
+  count: number;
+  /** Top producing wells */
+  producers: TopProducingWell[];
+}
+
+/**
+ * Options for `states()`
+ */
+export interface StatesOptions {
+  /** Month to query (YYYY-MM). Defaults to the latest available month. */
+  period?: string;
+}
+
+/**
+ * Options for `stateDetail()`
+ */
+export interface StateDetailOptions {
+  /** Start date (YYYY-MM-DD). Defaults to 2 years ago. */
+  start_date?: string;
+  /** End date (YYYY-MM-DD). Defaults to today. */
+  end_date?: string;
+}
+
+/**
+ * Options for `topProducers()`
+ */
+export interface TopProducersOptions {
+  /** Two-letter state code (default "TX") */
+  state_code?: string;
+  /** Max wells to return (default 20, capped at 100 server-side) */
+  limit?: number;
+  /** Lookback window in months (default 12) */
+  months?: number;
+}
+
+/**
+ * Cycle-time distribution statistics (days)
+ */
+export interface CycleTimeStats {
+  count: number;
+  median_days: number | null;
+  p25_days: number | null;
+  p75_days: number | null;
+  p90_days: number | null;
+  min_days: number | null;
+  max_days: number | null;
+  avg_days: number | null;
+}
+
+/**
+ * A notably fast/slow well in the cycle-time analysis
+ */
+export interface CycleTimeWell {
+  /** 14-digit API well number */
+  api_number: string;
+  /** Operator name */
+  operator: string | null;
+  /** Permit-to-production days */
+  total_days: number;
+  /** Permit date (YYYY-MM-DD) */
+  permit_date: string | null;
+  /** First production month (YYYY-MM-DD) */
+  first_production: string | null;
+}
+
+/**
+ * Permit-to-production cycle-time analysis
+ * (GET /v1/well-production/cycle-time)
+ */
+export interface CycleTimeAnalysis {
+  /** Echo of the applied filters */
+  filters: Record<string, unknown>;
+  /** Wells matching the filters */
+  well_count: number;
+  /** Wells with both permit and production dates */
+  wells_with_cycle_data: number;
+  /** Overall distribution statistics */
+  cycle_time_stats: CycleTimeStats;
+  /** Per-stage breakdown (permit→spud, spud→completion, ...) when available */
+  stage_breakdown: Record<string, unknown>;
+  /** Stats grouped by permit quarter (e.g., "2025-Q2") */
+  quarterly_cohorts: Record<
+    string,
+    { well_count: number; median_days: number | null; avg_days: number | null }
+  >;
+  /** Fastest wells in the sample */
+  top_fastest: CycleTimeWell[];
+  /** Slowest wells in the sample */
+  top_slowest: CycleTimeWell[];
+}
+
+/**
+ * Single cohort entry in a cycle-time cohort comparison
+ */
+export interface CycleTimeCohort {
+  well_count: number;
+  wells_with_data: number;
+  stats: CycleTimeStats;
+}
+
+/**
+ * Cycle-time cohort comparison
+ * (GET /v1/well-production/cycle-time/cohorts)
+ */
+export interface CycleTimeCohortsResponse {
+  /** Cohort grouping field (default "quarter") */
+  group_by: string;
+  /** Cohort label (e.g., "2025-Q2") → cohort stats */
+  cohorts: Record<string, CycleTimeCohort>;
+}
+
+/**
+ * Filters for `cycleTime()`
+ */
+export interface CycleTimeQuery {
+  /** Two-letter state code */
+  state?: string;
+  /** Permit date >= (YYYY-MM-DD). Defaults to 24 months ago when no dates given. */
+  start_date?: string;
+  /** Permit date <= (YYYY-MM-DD) */
+  end_date?: string;
+  /** Operator name (partial match) */
+  operator?: string;
+  /** Target formation (partial match) */
+  formation?: string;
+  /** Latitude for radius search */
+  lat?: number;
+  /** Longitude for radius search */
+  lng?: number;
+  /** Radius in miles for lat/lng search */
+  radius_miles?: number;
+}
+
+/**
+ * Filters for `cycleTimeCohorts()`
+ */
+export interface CycleTimeCohortsQuery {
+  /** Two-letter state code */
+  state?: string;
+  /** Permit date >= (YYYY-MM-DD) */
+  start_date?: string;
+  /** Permit date <= (YYYY-MM-DD) */
+  end_date?: string;
+  /** Latitude for radius search */
+  lat?: number;
+  /** Longitude for radius search */
+  lng?: number;
+  /** Radius in miles for lat/lng search */
+  radius_miles?: number;
+  /** Cohort grouping field (default "quarter") */
+  group_by?: string;
+}
+
+/**
+ * Well Production Resource
+ *
+ * US oil & gas production data (requires the drilling-intelligence tier).
+ *
+ * Beta coverage caveat: well-level records exist only for the states collected
+ * from regulatory agencies so far — check `summary().coverage` before assuming
+ * a state or well is covered.
+ *
+ * @example
+ * ```typescript
+ * const client = new OilPriceAPI({ apiKey: 'your_key' });
+ *
+ * // National overview + top states
+ * const summary = await client.wellProduction.summary();
+ * console.log(summary.top_states[0]); // { state: 'TX', oil_bbl: ..., ... }
+ *
+ * // Texas production history
+ * const tx = await client.wellProduction.stateDetail('TX', { start_date: '2026-01-01' });
+ * tx.data.forEach(r => console.log(`${r.period}: ${r.oil_bbl} bbl`));
+ *
+ * // Permit-to-production cycle times
+ * const cycle = await client.wellProduction.cycleTime({ state: 'TX' });
+ * console.log(`Median: ${cycle.cycle_time_stats.median_days} days`);
+ * ```
+ */
+export class WellProductionResource {
+  constructor(private client: OilPriceAPI) {}
+
+  /**
+   * Get the national production overview: latest national rollup, top
+   * producing states, data sources, and coverage metadata.
+   *
+   * `GET /v1/well-production`
+   */
+  async summary(): Promise<WellProductionSummary> {
+    return this.client["request"]<WellProductionSummary>("/v1/well-production", {});
+  }
+
+  /**
+   * Get the latest (or a specific month's) state-level production summary.
+   *
+   * `GET /v1/well-production/states`
+   *
+   * @param options - Optional `{ period: 'YYYY-MM' }`
+   */
+  async states(options?: StatesOptions): Promise<StatesProductionResponse> {
+    const params: Record<string, string> = {};
+    if (options?.period) params.period = options.period;
+
+    return this.client["request"]<StatesProductionResponse>("/v1/well-production/states", params);
+  }
+
+  /**
+   * Get monthly production history for a specific state.
+   *
+   * `GET /v1/well-production/states/:state_code`
+   *
+   * @param stateCode - Two-letter state code (e.g., "TX")
+   * @param options - Optional date range
+   * @throws {NotFoundError} When the state has no production data
+   */
+  async stateDetail(
+    stateCode: string,
+    options?: StateDetailOptions,
+  ): Promise<StateProductionDetail> {
+    if (!stateCode || typeof stateCode !== "string") {
+      throw new ValidationError("State code must be a non-empty string");
+    }
+
+    const params: Record<string, string> = {};
+    if (options?.start_date) params.start_date = options.start_date;
+    if (options?.end_date) params.end_date = options.end_date;
+
+    return this.client["request"]<StateProductionDetail>(
+      `/v1/well-production/states/${encodeURIComponent(stateCode)}`,
+      params,
+    );
+  }
+
+  /**
+   * Get monthly production history for a specific well.
+   *
+   * `GET /v1/well-production/wells/:api_number`
+   *
+   * @param apiNumber - 14-digit API well number (separators like "42-477-31122-00-00" are accepted)
+   * @throws {ValidationError} When the API number doesn't contain 14 digits
+   * @throws {NotFoundError} When the well has no production data
+   */
+  async wellDetail(apiNumber: string): Promise<WellProductionDetail> {
+    if (!apiNumber || typeof apiNumber !== "string") {
+      throw new ValidationError("API number must be a non-empty string");
+    }
+
+    const digits = apiNumber.replace(/[^0-9]/g, "");
+    if (digits.length !== 14) {
+      throw new ValidationError("API number must be 14 digits");
+    }
+
+    return this.client["request"]<WellProductionDetail>(`/v1/well-production/wells/${digits}`, {});
+  }
+
+  /**
+   * Get top producing wells for a state over a lookback window.
+   *
+   * `GET /v1/well-production/top-producers`
+   *
+   * @param options - Optional state_code (default "TX"), limit, months
+   */
+  async topProducers(options?: TopProducersOptions): Promise<TopProducersResponse> {
+    const params: Record<string, string> = {};
+    if (options?.state_code) params.state_code = options.state_code;
+    if (options?.limit !== undefined) params.limit = options.limit.toString();
+    if (options?.months !== undefined) params.months = options.months.toString();
+
+    return this.client["request"]<TopProducersResponse>(
+      "/v1/well-production/top-producers",
+      params,
+    );
+  }
+
+  /**
+   * Analyze permit-to-production cycle times with optional geographic,
+   * operator, and formation filters.
+   *
+   * `GET /v1/well-production/cycle-time`
+   *
+   * @param query - Optional filters
+   * @throws {NotFoundError} When no wells match the filters
+   */
+  async cycleTime(query?: CycleTimeQuery): Promise<CycleTimeAnalysis> {
+    const params: Record<string, string> = {};
+    if (query?.state) params.state = query.state;
+    if (query?.start_date) params.start_date = query.start_date;
+    if (query?.end_date) params.end_date = query.end_date;
+    if (query?.operator) params.operator = query.operator;
+    if (query?.formation) params.formation = query.formation;
+    if (query?.lat !== undefined) params.lat = query.lat.toString();
+    if (query?.lng !== undefined) params.lng = query.lng.toString();
+    if (query?.radius_miles !== undefined) params.radius_miles = query.radius_miles.toString();
+
+    return this.client["request"]<CycleTimeAnalysis>("/v1/well-production/cycle-time", params);
+  }
+
+  /**
+   * Compare cycle times across cohorts (quarterly by default).
+   *
+   * `GET /v1/well-production/cycle-time/cohorts`
+   *
+   * @param query - Optional filters plus `group_by`
+   * @throws {NotFoundError} When no wells match the filters
+   */
+  async cycleTimeCohorts(query?: CycleTimeCohortsQuery): Promise<CycleTimeCohortsResponse> {
+    const params: Record<string, string> = {};
+    if (query?.state) params.state = query.state;
+    if (query?.start_date) params.start_date = query.start_date;
+    if (query?.end_date) params.end_date = query.end_date;
+    if (query?.lat !== undefined) params.lat = query.lat.toString();
+    if (query?.lng !== undefined) params.lng = query.lng.toString();
+    if (query?.radius_miles !== undefined) params.radius_miles = query.radius_miles.toString();
+    if (query?.group_by) params.group_by = query.group_by;
+
+    return this.client["request"]<CycleTimeCohortsResponse>(
+      "/v1/well-production/cycle-time/cohorts",
+      params,
+    );
+  }
+}

--- a/tests/resources/ei.test.ts
+++ b/tests/resources/ei.test.ts
@@ -221,8 +221,14 @@ describe("EnergyIntelligenceResource (ei.*)", () => {
   // -------------------------------------------------------------------------
   describe("wellPermits", () => {
     it("covers list/latest/summary/byState/byOperator/byFormation", async () => {
-      spy({ id: "1", state: "TX", issue_date: "d", timestamp: "t" });
-      await client.ei.wellPermits.latest();
+      // latest() returns the live collection envelope { well_permits, meta } (#32).
+      spy({
+        well_permits: [{ api_number: "42", state_code: "TX", operator: { name: "Op" } }],
+        meta: { count: 1, limit: 25 },
+      });
+      const latest = await client.ei.wellPermits.latest();
+      expect(latest.well_permits).toHaveLength(1);
+      expect(latest.meta?.count).toBe(1);
 
       spy({ total_permits: 1, as_of_date: "d" });
       await client.ei.wellPermits.summary();

--- a/tests/resources/well-production.test.ts
+++ b/tests/resources/well-production.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { OilPriceAPI } from "../../src/client.js";
+import { NotFoundError, OilPriceAPIError, ValidationError } from "../../src/errors.js";
+
+/**
+ * Well Production (client.wellProduction) unit tests — issue #32.
+ *
+ * Covers:
+ * - Endpoint paths and query params for all /v1/well-production* routes
+ *   (mocked private client.request, same pattern as ei.test.ts).
+ * - Response-envelope unwrapping at the fetch level using live-captured
+ *   { status: "success", data: { ... } } fixtures.
+ * - Negative paths: entitlement (402/403), unsupported state (404),
+ *   invalid API number (client-side + server 400), and empty successful
+ *   responses.
+ */
+describe("WellProductionResource (client.wellProduction)", () => {
+  let client: OilPriceAPI;
+
+  beforeEach(() => {
+    client = new OilPriceAPI({ apiKey: "test_key_123", retries: 0, retryDelay: 1 });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function spy(resolved: unknown) {
+    return vi.spyOn(client as any, "request").mockResolvedValue(resolved);
+  }
+
+  /** Mock global fetch with a successful { status: "success", data } envelope. */
+  function mockFetchSuccess(data: unknown) {
+    return vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers(),
+      text: async () => JSON.stringify({ status: "success", data }),
+    } as Response);
+  }
+
+  /** Mock global fetch with an API error envelope (matches live error shape). */
+  function mockFetchError(status: number, statusText: string, body: unknown) {
+    return vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status,
+      statusText,
+      headers: new Headers(),
+      text: async () => JSON.stringify(body),
+    } as Response);
+  }
+
+  // ---------------------------------------------------------------------
+  // Endpoint paths + params
+  // ---------------------------------------------------------------------
+  describe("endpoint mapping", () => {
+    it("summary() hits GET /v1/well-production", async () => {
+      const s = spy({ national: null, top_states: [] });
+      await client.wellProduction.summary();
+      expect(s).toHaveBeenCalledWith("/v1/well-production", {});
+    });
+
+    it("states() hits /states with no params by default", async () => {
+      const s = spy({ period: "2026-04", count: 0, states: [] });
+      await client.wellProduction.states();
+      expect(s).toHaveBeenCalledWith("/v1/well-production/states", {});
+    });
+
+    it("states() passes period param", async () => {
+      const s = spy({ period: "2026-04", count: 0, states: [] });
+      await client.wellProduction.states({ period: "2026-04" });
+      expect(s).toHaveBeenCalledWith("/v1/well-production/states", { period: "2026-04" });
+    });
+
+    it("stateDetail() hits /states/:code and passes date range", async () => {
+      const s = spy({ state: "TX", period: { start: "s", end: "e" }, count: 0, data: [] });
+      await client.wellProduction.stateDetail("TX", {
+        start_date: "2026-01-01",
+        end_date: "2026-06-30",
+      });
+      expect(s).toHaveBeenCalledWith("/v1/well-production/states/TX", {
+        start_date: "2026-01-01",
+        end_date: "2026-06-30",
+      });
+    });
+
+    it("wellDetail() normalizes separators and hits /wells/:api", async () => {
+      const s = spy({ api_number: "42477311220000", count: 0, data: [] });
+      await client.wellProduction.wellDetail("42-477-31122-00-00");
+      expect(s).toHaveBeenCalledWith("/v1/well-production/wells/42477311220000", {});
+    });
+
+    it("topProducers() stringifies limit/months and passes state_code", async () => {
+      const s = spy({ state: "NM", period: { start: "s", end: "e" }, count: 0, producers: [] });
+      await client.wellProduction.topProducers({ state_code: "NM", limit: 5, months: 6 });
+      expect(s).toHaveBeenCalledWith("/v1/well-production/top-producers", {
+        state_code: "NM",
+        limit: "5",
+        months: "6",
+      });
+    });
+
+    it("cycleTime() passes all supported filters", async () => {
+      const s = spy({
+        filters: {},
+        well_count: 0,
+        wells_with_cycle_data: 0,
+        cycle_time_stats: {},
+        stage_breakdown: {},
+        quarterly_cohorts: {},
+        top_fastest: [],
+        top_slowest: [],
+      });
+      await client.wellProduction.cycleTime({
+        state: "TX",
+        start_date: "2025-01-01",
+        end_date: "2025-12-31",
+        operator: "Comstock",
+        formation: "Eagle Ford",
+        lat: 31.5,
+        lng: -102.1,
+        radius_miles: 25,
+      });
+      expect(s).toHaveBeenCalledWith("/v1/well-production/cycle-time", {
+        state: "TX",
+        start_date: "2025-01-01",
+        end_date: "2025-12-31",
+        operator: "Comstock",
+        formation: "Eagle Ford",
+        lat: "31.5",
+        lng: "-102.1",
+        radius_miles: "25",
+      });
+    });
+
+    it("cycleTimeCohorts() passes filters and group_by", async () => {
+      const s = spy({ group_by: "quarter", cohorts: {} });
+      await client.wellProduction.cycleTimeCohorts({ state: "TX", group_by: "state" });
+      expect(s).toHaveBeenCalledWith("/v1/well-production/cycle-time/cohorts", {
+        state: "TX",
+        group_by: "state",
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Client-side validation
+  // ---------------------------------------------------------------------
+  describe("validation", () => {
+    it("stateDetail() rejects empty state code", async () => {
+      await expect(client.wellProduction.stateDetail("")).rejects.toThrow(ValidationError);
+      await expect(client.wellProduction.stateDetail("")).rejects.toThrow(
+        "State code must be a non-empty string",
+      );
+    });
+
+    it("wellDetail() rejects empty API number", async () => {
+      await expect(client.wellProduction.wellDetail("")).rejects.toThrow(ValidationError);
+    });
+
+    it("wellDetail() rejects API numbers without 14 digits", async () => {
+      await expect(client.wellProduction.wellDetail("1234")).rejects.toThrow(
+        "API number must be 14 digits",
+      );
+      await expect(client.wellProduction.wellDetail("42-477-31122-00-001")).rejects.toThrow(
+        ValidationError,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Response envelopes (fetch-level, live-captured fixtures)
+  // ---------------------------------------------------------------------
+  describe("response envelopes", () => {
+    it("summary() unwraps { status, data } and preserves national/top_states/coverage", async () => {
+      // Fixture captured from live GET /v1/well-production (2026-07-13).
+      mockFetchSuccess({
+        national: {
+          period: "2026-07",
+          oil_bbl: 0,
+          gas_mcf: 0,
+          water_bbl: 0,
+          boe: 0,
+          days_producing: null,
+          source: "market_reporting",
+        },
+        top_states: [
+          {
+            state: "TX",
+            period: "2026-04",
+            oil_bbl: 174743000,
+            oil_bpd: 5824767,
+            gas_mcf: 1164406000,
+            boe: 368810667,
+          },
+        ],
+        data_sources: { state_aggregates: "EIA API v2 (monthly)" },
+        coverage: { well_level_states_with_data: ["AK", "ND", "NM", "PA", "TX"] },
+      });
+
+      const summary = await client.wellProduction.summary();
+      expect(summary.national?.source).toBe("market_reporting");
+      expect(summary.top_states[0].state).toBe("TX");
+      expect(summary.top_states[0].oil_bpd).toBe(5824767);
+      expect(summary.coverage?.well_level_states_with_data).toContain("TX");
+    });
+
+    it("stateDetail() returns the state history envelope", async () => {
+      // Fixture captured from live GET /v1/well-production/states/TX (2026-07-13).
+      mockFetchSuccess({
+        state: "TX",
+        period: { start: "2026-01-01", end: "2026-07-13" },
+        count: 1,
+        data: [
+          {
+            period: "2026-01",
+            oil_bbl: 172442000,
+            gas_mcf: 1156809000,
+            water_bbl: null,
+            boe: 365243500,
+            days_producing: null,
+            source: "eia_api",
+          },
+        ],
+      });
+
+      const detail = await client.wellProduction.stateDetail("TX");
+      expect(detail.state).toBe("TX");
+      expect(detail.count).toBe(1);
+      expect(detail.data[0].source).toBe("eia_api");
+      expect(detail.data[0].water_bbl).toBeNull();
+    });
+
+    it("cycleTimeCohorts() returns group_by and cohort stats", async () => {
+      // Fixture captured from live GET /v1/well-production/cycle-time/cohorts?state=TX.
+      mockFetchSuccess({
+        group_by: "quarter",
+        cohorts: {
+          "2025-Q3": {
+            well_count: 1,
+            wells_with_data: 1,
+            stats: {
+              count: 1,
+              median_days: 46,
+              p25_days: 46,
+              p75_days: 46,
+              p90_days: 46,
+              min_days: 46,
+              max_days: 46,
+              avg_days: 46,
+            },
+          },
+        },
+      });
+
+      const cohorts = await client.wellProduction.cycleTimeCohorts({ state: "TX" });
+      expect(cohorts.group_by).toBe("quarter");
+      expect(cohorts.cohorts["2025-Q3"].stats.median_days).toBe(46);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Negative paths
+  // ---------------------------------------------------------------------
+  describe("negative paths", () => {
+    it("maps 403 ENTERPRISE_REQUIRED (live entitlement gate) to OilPriceAPIError", async () => {
+      // Live shape: { error: { code: 'ENTERPRISE_REQUIRED', message, status: 403 } }
+      mockFetchError(403, "Forbidden", {
+        error: {
+          code: "ENTERPRISE_REQUIRED",
+          message: "Well production data requires the Scale plan.",
+          status: 403,
+        },
+      });
+
+      const err = await client.wellProduction.summary().catch((e) => e);
+      expect(err).toBeInstanceOf(OilPriceAPIError);
+      expect(err.statusCode).toBe(403);
+      expect(err).not.toBeInstanceOf(NotFoundError);
+    });
+
+    it("maps 402 payment-required entitlement responses to OilPriceAPIError", async () => {
+      mockFetchError(402, "Payment Required", {
+        message: "Upgrade required to access well production data.",
+      });
+
+      const err = await client.wellProduction.states().catch((e) => e);
+      expect(err).toBeInstanceOf(OilPriceAPIError);
+      expect(err.statusCode).toBe(402);
+      expect(err.message).toContain("Upgrade required");
+    });
+
+    it("maps 404 DATA_NOT_AVAILABLE (unsupported state) to NotFoundError", async () => {
+      // Fixture captured from live GET /v1/well-production/states/ZZ (2026-07-13).
+      mockFetchError(404, "Not Found", {
+        error: {
+          code: "DATA_NOT_AVAILABLE",
+          message: "No production data for state: ZZ",
+          status: 404,
+        },
+      });
+
+      await expect(client.wellProduction.stateDetail("ZZ")).rejects.toThrow(NotFoundError);
+    });
+
+    it("maps 404 for a well with no production data to NotFoundError", async () => {
+      mockFetchError(404, "Not Found", {
+        error: {
+          code: "DATA_NOT_AVAILABLE",
+          message: "No production data for well: 99999999999999",
+          status: 404,
+        },
+      });
+
+      await expect(client.wellProduction.wellDetail("99999999999999")).rejects.toThrow(
+        NotFoundError,
+      );
+    });
+
+    it("maps server-side 400 INVALID_PARAMETER to OilPriceAPIError with status 400", async () => {
+      // e.g. states({ period: 'bad-format' }) → 400 on some deployments.
+      mockFetchError(400, "Bad Request", {
+        error: {
+          code: "INVALID_PARAMETER",
+          message: "Invalid period format. Use YYYY-MM.",
+          status: 400,
+        },
+      });
+
+      const err = await client.wellProduction.states({ period: "bad" }).catch((e) => e);
+      expect(err).toBeInstanceOf(OilPriceAPIError);
+      expect(err.statusCode).toBe(400);
+    });
+
+    it("handles empty successful responses (no states for period)", async () => {
+      // Live behaviour for GET /v1/well-production/states?period=<unknown>.
+      mockFetchSuccess({ period: "1990-01", count: 0, states: [] });
+
+      const res = await client.wellProduction.states({ period: "1990-01" });
+      expect(res.count).toBe(0);
+      expect(res.states).toEqual([]);
+    });
+
+    it("handles empty top-producers responses", async () => {
+      mockFetchSuccess({
+        state: "TX",
+        period: { start: "2025-07-13", end: "2026-07-13" },
+        count: 0,
+        producers: [],
+      });
+
+      const res = await client.wellProduction.topProducers();
+      expect(res.count).toBe(0);
+      expect(res.producers).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #32.

## What

### 1. New `client.wellProduction` resource (`src/resources/well-production.ts`)

Typed coverage for all seven `/v1/well-production*` endpoints:

| Method                                           | Endpoint                                     |
| ------------------------------------------------ | -------------------------------------------- |
| `summary()`                                      | `GET /v1/well-production`                    |
| `states({ period? })`                            | `GET /v1/well-production/states`             |
| `stateDetail(code, { start_date?, end_date? })`  | `GET /v1/well-production/states/:state_code` |
| `wellDetail(apiNumber)`                          | `GET /v1/well-production/wells/:api_number`  |
| `topProducers({ state_code?, limit?, months? })` | `GET /v1/well-production/top-producers`      |
| `cycleTime(filters?)`                            | `GET /v1/well-production/cycle-time`         |
| `cycleTimeCohorts(filters?)`                     | `GET /v1/well-production/cycle-time/cohorts` |

Response types were written against live-captured envelopes (2026-07-13), not guessed. `wellDetail()` normalizes separator formats (`42-477-31122-00-00`) and validates 14 digits client-side, matching the server rule.

### 2. `ei.wellPermits.latest()` envelope fix (per #32 acceptance criteria)

The live API returns `{ well_permits: [...], meta: {...} }`, not a single record. `latest()` now returns a typed `WellPermitLatestResponse` (with new `LatestWellPermit` nested-record type). The old `WellPermitRecord` return type never matched runtime behavior.

### 3. README

New "Well Production" section with the **beta coverage caveat**: well-level data covers only regulator-collected states (AK/ND/NM/PA/TX today) — no complete-US well-level claim; EIA state aggregates are the comprehensive layer.

### 4. Security: committed credentials removed

`example.ts`, `example-walk.ts` (4x), `example-commodities.ts`, and `qa_test.js` contained a hardcoded API key. All literals are replaced with `OILPRICEAPI_KEY` env-var usage; examples exit with a clear message when unset and `qa_test.js` skips cleanly. **The exposed key must be rotated server-side — it remains in git history.**

### 5. Hygiene

- Added `.github/dependabot.yml` (weekly npm + github-actions, grouped dev-dep minor/patch).

## Test evidence

```
npm test         → Test Files 29 passed (29); Tests 450 passed | 1 skipped (451)
npm run build    → clean (ESM + CJS)
npm run lint     → 0 errors (10 pre-existing warnings in alerts.ts)
npm audit        → 0 vulnerabilities
```

New suite `tests/resources/well-production.test.ts` (18 tests): endpoint paths/params for all 7 routes, envelope unwrapping from live fixtures, and negative paths — 403 `ENTERPRISE_REQUIRED` (the actual live entitlement gate), 402, 404 `DATA_NOT_AVAILABLE` (unsupported state + unknown well), 400 `INVALID_PARAMETER`, client-side `ValidationError`s, and empty successful responses. All tests are mock-based and pass without an API key.

Live smoke (built `dist/`, production API):

```
summary top state: TX 2026-04
stateDetail TX count: 4 eia_api
cohorts group_by: quarter [ '2025-Q2', '2025-Q3' ]
ZZ -> NotFoundError 404
wellPermits.latest: 25 meta.count 25
```

## Known backend issue (not SDK-fixable)

`GET /v1/well-production/top-producers` returns **HTTP 500** on production (probed 2026-07-13). The SDK maps the controller's documented shape; needs a backend fix in oilpriceapi-api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
