### PR TITLE
chore: sync package lock version for 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi",
-  "version": "0.9.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi",
-      "version": "0.9.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.21.0"


### PR DESCRIPTION
## Summary
- updates the root `package-lock.json` package version from stale `0.9.1` to `1.0.2`
- keeps lockfile metadata aligned with `package.json` and `src/version.ts` before publishing/tagging `1.0.2`

## Verification
- `npm test`
- `npm run build`
- `npm run lint` (passes with existing warnings)