### PR TITLE
fix: make exported snippets standalone

### DIFF
--- a/examples/snippets/_shared.ts
+++ b/examples/snippets/_shared.ts
@@ -1,9 +1,0 @@
-import { pathToFileURL } from "node:url";
-
-export function fixtureBaseUrl(): string | undefined {
-  return process.env.OILPRICEAPI_BASE_URL;
-}
-
-export function isMain(importMetaUrl: string): boolean {
-  return Boolean(process.argv[1]) && importMetaUrl === pathToFileURL(process.argv[1]).href;
-}

--- a/examples/snippets/authentication-error.ts
+++ b/examples/snippets/authentication-error.ts
@@ -1,8 +1,13 @@
+import { pathToFileURL } from "node:url";
+
 import { AuthenticationError, OilPriceAPI } from "oilpriceapi";
-import { fixtureBaseUrl, isMain } from "./_shared.js";
 
 export async function run() {
-  const client = new OilPriceAPI({ baseUrl: fixtureBaseUrl(), retries: 0 });
+  const client = new OilPriceAPI({
+    apiKey: process.env.OILPRICEAPI_KEY,
+    baseUrl: process.env.OILPRICEAPI_BASE_URL,
+    retries: 0,
+  });
 
   try {
     await client.getLatestPrices({ commodity: "BRENT_CRUDE_USD" });
@@ -16,6 +21,6 @@ export async function run() {
   throw new Error("Expected the API to reject the credential");
 }
 
-if (isMain(import.meta.url)) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   console.log(JSON.stringify(await run()));
 }

--- a/examples/snippets/entitlement-error.ts
+++ b/examples/snippets/entitlement-error.ts
@@ -1,8 +1,13 @@
+import { pathToFileURL } from "node:url";
+
 import { OilPriceAPI, OilPriceAPIError } from "oilpriceapi";
-import { fixtureBaseUrl, isMain } from "./_shared.js";
 
 export async function run() {
-  const client = new OilPriceAPI({ baseUrl: fixtureBaseUrl(), retries: 0 });
+  const client = new OilPriceAPI({
+    apiKey: process.env.OILPRICEAPI_KEY,
+    baseUrl: process.env.OILPRICEAPI_BASE_URL,
+    retries: 0,
+  });
 
   try {
     await client.getLatestPrices({ commodity: "BRENT_CRUDE_USD" });
@@ -16,6 +21,6 @@ export async function run() {
   throw new Error("Expected the API to reject the account entitlement");
 }
 
-if (isMain(import.meta.url)) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   console.log(JSON.stringify(await run()));
 }

--- a/examples/snippets/history.ts
+++ b/examples/snippets/history.ts
@@ -1,9 +1,11 @@
+import { pathToFileURL } from "node:url";
+
 import { OilPriceAPI } from "oilpriceapi";
-import { fixtureBaseUrl, isMain } from "./_shared.js";
 
 export async function run() {
   const client = new OilPriceAPI({
-    baseUrl: fixtureBaseUrl(),
+    apiKey: process.env.OILPRICEAPI_KEY,
+    baseUrl: process.env.OILPRICEAPI_BASE_URL,
     retries: 0,
   });
   const prices = await client.getHistoricalPrices({
@@ -20,6 +22,6 @@ export async function run() {
   };
 }
 
-if (isMain(import.meta.url)) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   console.log(JSON.stringify(await run()));
 }

--- a/examples/snippets/latest-price.ts
+++ b/examples/snippets/latest-price.ts
@@ -1,9 +1,11 @@
+import { pathToFileURL } from "node:url";
+
 import { OilPriceAPI } from "oilpriceapi";
-import { fixtureBaseUrl, isMain } from "./_shared.js";
 
 export async function run() {
   const client = new OilPriceAPI({
-    baseUrl: fixtureBaseUrl(),
+    apiKey: process.env.OILPRICEAPI_KEY,
+    baseUrl: process.env.OILPRICEAPI_BASE_URL,
     retries: 0,
   });
   const [price] = await client.getLatestPrices({ commodity: "BRENT_CRUDE_USD" });
@@ -16,6 +18,6 @@ export async function run() {
   };
 }
 
-if (isMain(import.meta.url)) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   console.log(JSON.stringify(await run()));
 }

--- a/examples/snippets/rate-limit-error.ts
+++ b/examples/snippets/rate-limit-error.ts
@@ -1,8 +1,13 @@
+import { pathToFileURL } from "node:url";
+
 import { OilPriceAPI, RateLimitError } from "oilpriceapi";
-import { fixtureBaseUrl, isMain } from "./_shared.js";
 
 export async function run() {
-  const client = new OilPriceAPI({ baseUrl: fixtureBaseUrl(), retries: 0 });
+  const client = new OilPriceAPI({
+    apiKey: process.env.OILPRICEAPI_KEY,
+    baseUrl: process.env.OILPRICEAPI_BASE_URL,
+    retries: 0,
+  });
 
   try {
     await client.getLatestPrices({ commodity: "BRENT_CRUDE_USD" });
@@ -16,6 +21,6 @@ export async function run() {
   throw new Error("Expected the API to enforce its request limit");
 }
 
-if (isMain(import.meta.url)) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   console.log(JSON.stringify(await run()));
 }

--- a/examples/snippets/timeout-error.ts
+++ b/examples/snippets/timeout-error.ts
@@ -1,9 +1,11 @@
+import { pathToFileURL } from "node:url";
+
 import { OilPriceAPI, TimeoutError } from "oilpriceapi";
-import { fixtureBaseUrl, isMain } from "./_shared.js";
 
 export async function run() {
   const client = new OilPriceAPI({
-    baseUrl: fixtureBaseUrl(),
+    apiKey: process.env.OILPRICEAPI_KEY,
+    baseUrl: process.env.OILPRICEAPI_BASE_URL,
     retries: 0,
     timeout: 20,
   });
@@ -20,6 +22,6 @@ export async function run() {
   throw new Error("Expected the request to time out");
 }
 
-if (isMain(import.meta.url)) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   console.log(JSON.stringify(await run()));
 }

--- a/tests/snippet-manifest.test.ts
+++ b/tests/snippet-manifest.test.ts
@@ -54,6 +54,10 @@ describe("versioned snippet manifest", () => {
       403,
       429,
     ]);
+    for (const example of manifest.examples) {
+      expect(example.code).toContain("OILPRICEAPI_KEY");
+      expect(example.code).not.toContain("_shared");
+    }
   });
 
   it("executes the exact success files against fixtures", async () => {


### PR DESCRIPTION
## Summary
- remove the private `_shared` dependency from all six exported examples
- read `OILPRICEAPI_KEY` explicitly and keep `OILPRICEAPI_BASE_URL` as the CI-only override
- assert every manifest example is standalone and preserves the canonical environment variable

## Verification
- `npm run snippets:check`
- `npm test`: 454 passed, 1 skipped
- `npm run lint`: 0 errors
- `npm run build`

Follow-up to #49 and producer issue #48. Required before website consumer OilpriceAPI/website-clean#1238 is pinned.