### PR TITLE
feat: normalize SDK API error contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ import {
   OilPriceAPIError,
   RateLimitError,
   TimeoutError,
+  isEntitlementError,
+  isQuotaError,
 } from "oilpriceapi";
 
 const client = new OilPriceAPI({ apiKey: process.env.OILPRICEAPI_KEY });
@@ -130,11 +132,12 @@ try {
     console.error("Wait for the API-provided reset window.");
   } else if (error instanceof TimeoutError) {
     console.error("Retry once, then check https://status.oilpriceapi.com.");
-  } else if (
-    error instanceof OilPriceAPIError &&
-    (error.statusCode === 402 || error.statusCode === 403)
-  ) {
-    console.error("Review dataset access for this account.");
+  } else if (isQuotaError(error)) {
+    console.error(`Monthly quota reached; ${error.remediationUrl ?? "review the account"}.`);
+  } else if (isEntitlementError(error)) {
+    console.error(`This dataset needs the ${error.requiredPlan ?? "required"} plan.`);
+  } else if (error instanceof OilPriceAPIError) {
+    console.error(error.requestId ? `Request ID: ${error.requestId}` : "Unexpected API error.");
   } else {
     throw error;
   }
@@ -145,6 +148,10 @@ Executable recovery examples cover 401, 403, 429, and timeout responses under
 [`examples/snippets/`](examples/snippets/). Empty or malformed successful
 responses should stop processing rather than inventing a price, unit, currency,
 source, or timestamp.
+
+All HTTP failures expose `statusCode`, `code`, `requestId`, recovery links and
+plan metadata when the API supplies them. `rawBody` and `headers` are retained
+for diagnostics; the configured API key is redacted before either is exposed.
 
 ## Capabilities
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,12 +15,11 @@ import type {
 import type { MarketBrief, MarketBriefOptions } from "./resources/market-brief.js";
 import {
   OilPriceAPIError,
-  AuthenticationError,
   RateLimitError,
-  NotFoundError,
   ServerError,
   TimeoutError,
   ValidationError,
+  errorFromResponse,
 } from "./errors.js";
 import { DieselResource } from "./resources/diesel.js";
 import { AlertsResource } from "./resources/alerts.js";
@@ -435,47 +434,15 @@ export class OilPriceAPI {
           // Handle error responses
           if (!response.ok) {
             const errorBody = await response.text();
-            let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+            const apiError = errorFromResponse(response, errorBody, this.apiKey);
+            this.log(`Error response: ${apiError.message}`);
 
-            // Try to parse JSON error response
-            try {
-              const errorJson = JSON.parse(errorBody);
-              errorMessage = errorJson.message || errorJson.error || errorMessage;
-            } catch {
-              // Use default error message if response isn't JSON
+            if (apiError instanceof RateLimitError && attempt < this.retries && apiError.retryAfter) {
+              this.log(`Rate limited. Waiting ${apiError.retryAfter}s`);
+              await this.sleep(apiError.retryAfter * 1000);
+              continue;
             }
-
-            this.log(`Error response: ${errorMessage}`);
-
-            // Throw specific error types based on status code
-            switch (response.status) {
-              case 401:
-                throw new AuthenticationError(errorMessage);
-              case 404:
-                throw new NotFoundError(errorMessage);
-              case 429:
-                const retryAfter = response.headers.get("Retry-After");
-                const rateLimitError = new RateLimitError(
-                  errorMessage,
-                  retryAfter ? parseInt(retryAfter, 10) : undefined,
-                );
-
-                // If rate limited and we have retries left, wait and retry
-                if (attempt < this.retries && rateLimitError.retryAfter) {
-                  this.log(`Rate limited. Waiting ${rateLimitError.retryAfter}s`);
-                  await this.sleep(rateLimitError.retryAfter * 1000);
-                  continue;
-                }
-
-                throw rateLimitError;
-              case 500:
-              case 502:
-              case 503:
-              case 504:
-                throw new ServerError(errorMessage, response.status);
-              default:
-                throw new OilPriceAPIError(errorMessage, response.status, "HTTP_ERROR");
-            }
+            throw apiError;
           }
 
           // Handle empty responses (e.g., 204 No Content from DELETE)
@@ -877,14 +844,7 @@ export class OilPriceAPI {
 
       if (!response.ok) {
         const body = await response.text();
-        let message = `HTTP ${response.status}: ${response.statusText}`;
-        try {
-          const json = JSON.parse(body);
-          message = json.message || json.error || message;
-        } catch {
-          // non-JSON error body
-        }
-        throw new OilPriceAPIError(message, response.status, "HTTP_ERROR");
+        throw errorFromResponse(response, body);
       }
 
       const parsed: any = JSON.parse(await response.text());

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,95 +1,151 @@
-/**
- * Base error class for all Oil Price API errors
- */
-export class OilPriceAPIError extends Error {
-  /**
-   * HTTP status code (if applicable)
-   */
+/** Structured diagnostics returned with an API or transport failure. */
+export interface OilPriceAPIErrorDetails {
   statusCode?: number;
-
-  /**
-   * Error code from the API
-   */
   code?: string;
+  requestId?: string;
+  docsUrl?: string;
+  currentPlan?: string;
+  requiredPlan?: string;
+  requiredFeature?: string;
+  remediationUrl?: string;
+  retryAfter?: number;
+  headers?: Record<string, string>;
+  rawBody?: unknown;
+}
 
-  constructor(message: string, statusCode?: number, code?: string) {
+/** Base class for every failure surfaced by the SDK. */
+export class OilPriceAPIError extends Error {
+  statusCode?: number;
+  code?: string;
+  requestId?: string;
+  docsUrl?: string;
+  currentPlan?: string;
+  requiredPlan?: string;
+  requiredFeature?: string;
+  remediationUrl?: string;
+  retryAfter?: number;
+  headers?: Record<string, string>;
+  rawBody?: unknown;
+
+  constructor(message: string, statusCode?: number, code?: string, details: OilPriceAPIErrorDetails = {}) {
     super(message);
     this.name = "OilPriceAPIError";
-    this.statusCode = statusCode;
-    this.code = code;
-
-    // Maintains proper stack trace for where our error was thrown (only available on V8)
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
+    Object.assign(this, { statusCode, code, ...details });
+    if (Error.captureStackTrace) Error.captureStackTrace(this, this.constructor);
   }
 }
 
-/**
- * Thrown when API authentication fails (401)
- */
 export class AuthenticationError extends OilPriceAPIError {
-  constructor(message: string = "Invalid API key") {
-    super(message, 401, "AUTHENTICATION_ERROR");
+  constructor(message = "Invalid API key", details: OilPriceAPIErrorDetails = {}) {
+    super(message, 401, "AUTHENTICATION_ERROR", details);
     this.name = "AuthenticationError";
   }
 }
 
-/**
- * Thrown when rate limit is exceeded (429)
- */
 export class RateLimitError extends OilPriceAPIError {
-  /**
-   * Number of seconds until rate limit resets
-   */
-  retryAfter?: number;
-
-  constructor(message: string = "Rate limit exceeded", retryAfter?: number) {
-    super(message, 429, "RATE_LIMIT_ERROR");
+  constructor(message = "Rate limit exceeded", retryAfter?: number, details: OilPriceAPIErrorDetails = {}) {
+    super(message, 429, "RATE_LIMIT_ERROR", { ...details, retryAfter });
     this.name = "RateLimitError";
-    this.retryAfter = retryAfter;
   }
 }
 
-/**
- * Thrown when requested resource is not found (404)
- */
 export class NotFoundError extends OilPriceAPIError {
-  constructor(message: string = "Resource not found") {
-    super(message, 404, "NOT_FOUND_ERROR");
+  constructor(message = "Resource not found", details: OilPriceAPIErrorDetails = {}) {
+    super(message, 404, "NOT_FOUND_ERROR", details);
     this.name = "NotFoundError";
   }
 }
 
-/**
- * Thrown when server returns 5xx error
- */
 export class ServerError extends OilPriceAPIError {
-  constructor(
-    message: string = "Internal server error",
-    statusCode: number = 500,
-  ) {
-    super(message, statusCode, "SERVER_ERROR");
+  constructor(message = "Internal server error", statusCode = 500, details: OilPriceAPIErrorDetails = {}) {
+    super(message, statusCode, "SERVER_ERROR", details);
     this.name = "ServerError";
   }
 }
 
-/**
- * Thrown when SDK-side input validation fails
- */
 export class ValidationError extends OilPriceAPIError {
-  constructor(message: string) {
-    super(message, undefined, "VALIDATION_ERROR");
+  constructor(message: string, details: OilPriceAPIErrorDetails = {}) {
+    super(message, undefined, "VALIDATION_ERROR", details);
     this.name = "ValidationError";
   }
 }
 
-/**
- * Thrown when request exceeds timeout
- */
 export class TimeoutError extends OilPriceAPIError {
-  constructor(message: string = "Request timeout", timeout: number) {
-    super(`${message} (${timeout}ms)`, undefined, "TIMEOUT_ERROR");
+  constructor(message = "Request timeout", timeout: number, details: OilPriceAPIErrorDetails = {}) {
+    super(`${message} (${timeout}ms)`, undefined, "TIMEOUT_ERROR", details);
     this.name = "TimeoutError";
   }
 }
+
+type ErrorEnvelope = Record<string, unknown>;
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function redact(value: unknown, apiKey?: string): unknown {
+  if (typeof value === "string") return apiKey ? value.split(apiKey).join("[REDACTED]") : value;
+  if (Array.isArray(value)) return value.map((item) => redact(item, apiKey));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value as ErrorEnvelope).map(([key, item]) => [key, redact(item, apiKey)]));
+  }
+  return value;
+}
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  return Object.fromEntries(headers.entries());
+}
+
+/** Convert canonical and legacy API failure envelopes into the public SDK contract. */
+export function errorFromResponse(response: Response, body: string, apiKey?: string): OilPriceAPIError {
+  const headers = response.headers || new Headers();
+  let parsed: ErrorEnvelope | undefined;
+  try {
+    const candidate = JSON.parse(body);
+    if (candidate && typeof candidate === "object") parsed = candidate as ErrorEnvelope;
+  } catch {
+    // Text and HTML failures retain the HTTP status fallback below.
+  }
+
+  const envelope = parsed && typeof parsed.error === "object" && parsed.error !== null
+    ? { ...parsed, ...(parsed.error as ErrorEnvelope) }
+    : parsed || {};
+  const safeBody = redact(parsed ?? body, apiKey);
+  const fallback = `HTTP ${response.status}: ${response.statusText}`;
+  const message = String(redact(stringValue(envelope.message) || stringValue(envelope.error_description) || stringValue(envelope.error) || fallback, apiKey));
+  const retryAfterHeader = headers.get("retry-after");
+  const retryAfter = numberValue(envelope.retry_after) ?? (retryAfterHeader && /^\d+$/.test(retryAfterHeader) ? Number(retryAfterHeader) : undefined);
+  const details: OilPriceAPIErrorDetails = {
+    statusCode: response.status,
+    code: stringValue(envelope.code) || stringValue(envelope.error_code),
+    requestId: stringValue(envelope.request_id) || headers.get("x-request-id") || undefined,
+    docsUrl: stringValue(envelope.docs_url) || stringValue(envelope.documentation_url),
+    currentPlan: stringValue(envelope.current_plan) || stringValue(envelope.plan),
+    requiredPlan: stringValue(envelope.required_plan),
+    requiredFeature: stringValue(envelope.required_feature) || stringValue(envelope.feature),
+    remediationUrl: stringValue(envelope.remediation_url) || stringValue(envelope.upgrade_url),
+    retryAfter,
+    headers: headersToRecord(headers),
+    rawBody: safeBody,
+  };
+
+  if (response.status === 401) return new AuthenticationError(message, details);
+  if (response.status === 404) return new NotFoundError(message, details);
+  if (response.status === 429) return new RateLimitError(message, retryAfter, details);
+  if (response.status >= 500) return new ServerError(message, response.status, details);
+  return new OilPriceAPIError(message, response.status, details.code || "HTTP_ERROR", details);
+}
+
+export const isHTTPError = (error: unknown, status: number): error is OilPriceAPIError =>
+  error instanceof OilPriceAPIError && error.statusCode === status;
+export const isAuthenticationError = (error: unknown): error is AuthenticationError => isHTTPError(error, 401);
+export const isQuotaError = (error: unknown): error is OilPriceAPIError => isHTTPError(error, 402);
+export const isEntitlementError = (error: unknown): error is OilPriceAPIError => isHTTPError(error, 403);
+export const isNotFoundError = (error: unknown): error is NotFoundError => isHTTPError(error, 404);
+export const isRateLimitError = (error: unknown): error is RateLimitError => isHTTPError(error, 429);
+export const isServerError = (error: unknown): error is OilPriceAPIError =>
+  error instanceof OilPriceAPIError && !!error.statusCode && error.statusCode >= 500 && error.statusCode <= 599;

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,7 +249,16 @@ export {
   ServerError,
   ValidationError,
   TimeoutError,
+  errorFromResponse,
+  isHTTPError,
+  isAuthenticationError,
+  isQuotaError,
+  isEntitlementError,
+  isNotFoundError,
+  isRateLimitError,
+  isServerError,
 } from "./errors.js";
+export type { OilPriceAPIErrorDetails } from "./errors.js";
 export { DieselResource } from "./resources/diesel.js";
 export { AlertsResource } from "./resources/alerts.js";
 export { CommoditiesResource } from "./resources/commodities.js";

--- a/tests/error-handling.test.ts
+++ b/tests/error-handling.test.ts
@@ -7,6 +7,9 @@ import {
   ServerError,
   TimeoutError,
   OilPriceAPIError,
+  isEntitlementError,
+  isQuotaError,
+  isRateLimitError,
 } from "../src/index.js";
 
 /**
@@ -121,6 +124,76 @@ describe("Error Handling", () => {
         expect(error).toBeInstanceOf(RateLimitError);
         expect((error as RateLimitError).retryAfter).toBe(60);
       }
+    });
+  });
+
+  describe("Structured API errors", () => {
+    it("normalizes the canonical nested envelope and recovery metadata", async () => {
+      const noRetryClient = new OilPriceAPI({ apiKey: "test_key_12345", retries: 0 });
+      const headers = new Headers({ "x-request-id": "req_123", "retry-after": "30" });
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 429,
+        statusText: "Too Many Requests",
+        headers,
+        text: async () => JSON.stringify({
+          error: {
+            code: "RATE_LIMITED",
+            message: "Slow down",
+            docs_url: "https://docs.oilpriceapi.com/guides/rate-limits",
+          },
+        }),
+      } as Response);
+
+      await expect(noRetryClient.getLatestPrices()).rejects.toSatisfy((error: unknown) => {
+        expect(isRateLimitError(error)).toBe(true);
+        const apiError = error as RateLimitError;
+        expect(apiError.code).toBe("RATE_LIMITED");
+        expect(apiError.requestId).toBe("req_123");
+        expect(apiError.retryAfter).toBe(30);
+        expect(apiError.docsUrl).toContain("rate-limits");
+        return true;
+      });
+    });
+
+    it("normalizes legacy quota and entitlement fields", async () => {
+      const noRetryClient = new OilPriceAPI({ apiKey: "test_key_12345", retries: 0 });
+      fetchSpy.mockResolvedValueOnce({
+        ok: false, status: 402, statusText: "Payment Required", headers: new Headers(),
+        text: async () => JSON.stringify({ error_code: "MONTHLY_QUOTA_EXCEEDED", message: "Quota reached", current_plan: "Starter", upgrade_url: "https://oilpriceapi.com/pricing" }),
+      } as Response);
+      await expect(noRetryClient.getLatestPrices()).rejects.toSatisfy((error: unknown) => {
+        expect(isQuotaError(error)).toBe(true);
+        expect((error as OilPriceAPIError).currentPlan).toBe("Starter");
+        expect((error as OilPriceAPIError).remediationUrl).toContain("pricing");
+        return true;
+      });
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: false, status: 403, statusText: "Forbidden", headers: new Headers(),
+        text: async () => JSON.stringify({ error: "Plan required", required_plan: "Scale", feature: "bulk_export" }),
+      } as Response);
+      await expect(noRetryClient.getLatestPrices()).rejects.toSatisfy((error: unknown) => {
+        expect(isEntitlementError(error)).toBe(true);
+        expect((error as OilPriceAPIError).requiredPlan).toBe("Scale");
+        expect((error as OilPriceAPIError).requiredFeature).toBe("bulk_export");
+        return true;
+      });
+    });
+
+    it("redacts the configured key from messages and raw diagnostics", async () => {
+      const apiKey = "secret_test_key_12345";
+      const noRetryClient = new OilPriceAPI({ apiKey, retries: 0 });
+      fetchSpy.mockResolvedValue({
+        ok: false, status: 400, statusText: "Bad Request", headers: new Headers(),
+        text: async () => JSON.stringify({ message: `Rejected ${apiKey}`, echoed_key: apiKey }),
+      } as Response);
+      await expect(noRetryClient.getLatestPrices()).rejects.toSatisfy((error: unknown) => {
+        const apiError = error as OilPriceAPIError;
+        expect(apiError.message).not.toContain(apiKey);
+        expect(JSON.stringify(apiError.rawBody)).not.toContain(apiKey);
+        return true;
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- normalize canonical and legacy error envelopes into one typed public contract
- expose request, plan, recovery, retry, header, and safe raw diagnostics
- route authenticated and keyless demo requests through the same parser
- add regression coverage for 402, 403, 429, nested envelopes, and key redaction

## Verification
- `npm test` — 458 passed, 1 skipped
- `npm run build`
- `npm run lint` — no errors (10 existing warnings)

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured API error details, including status codes, error codes, request IDs, retry guidance, plan information, and recovery links.
  * Added error-type helpers for identifying authentication, quota, entitlement, rate-limit, not-found, and server errors.
  * API keys are redacted from error messages and diagnostic response data.

* **Documentation**
  * Updated recovery guidance with the new error helpers and metadata available for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->