### PR TITLE
Fix keyless demo client contract

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -210,11 +210,6 @@ export class OilPriceAPI {
 
   constructor(config: OilPriceAPIConfig = {}) {
     this.apiKey = config.apiKey || process.env.OILPRICEAPI_KEY || "";
-    if (!this.apiKey) {
-      throw new OilPriceAPIError(
-        "API key required. Set OILPRICEAPI_KEY env var or pass apiKey in config.",
-      );
-    }
     this.baseUrl = config.baseUrl || "https://api.oilpriceapi.com";
     this.retries = config.retries !== undefined ? config.retries : 3;
     this.retryDelay = config.retryDelay || 1000;
@@ -245,6 +240,17 @@ export class OilPriceAPI {
     this.stream = new StreamingResource(this);
     this.subscriptions = new SubscriptionsResource(this);
     this.wellProduction = new WellProductionResource(this);
+  }
+
+  private requireApiKey(): string {
+    if (!this.apiKey) {
+      throw new OilPriceAPIError(
+        "API key required. Set OILPRICEAPI_KEY env var or pass apiKey in config.",
+        undefined,
+        "MISSING_API_KEY",
+      );
+    }
+    return this.apiKey;
   }
 
   /**
@@ -362,6 +368,8 @@ export class OilPriceAPI {
     params?: Record<string, string>,
     options?: { method?: string; body?: unknown; headers?: Record<string, string> },
   ): Promise<APIResponse<T>> {
+    const apiKey = this.requireApiKey();
+
     // Build URL with query parameters
     const url = new URL(`${this.baseUrl}${endpoint}`);
     if (params) {
@@ -391,7 +399,7 @@ export class OilPriceAPI {
         try {
           // Build headers with optional telemetry
           const headers: Record<string, string> = {
-            Authorization: `Token ${this.apiKey}`,
+            Authorization: `Token ${apiKey}`,
             "Content-Type": "application/json",
             "User-Agent": buildUserAgent(),
             "X-SDK-Name": SDK_NAME,
@@ -434,7 +442,7 @@ export class OilPriceAPI {
           // Handle error responses
           if (!response.ok) {
             const errorBody = await response.text();
-            const apiError = errorFromResponse(response, errorBody, this.apiKey);
+            const apiError = errorFromResponse(response, errorBody, apiKey);
             this.log(`Error response: ${apiError.message}`);
 
             if (apiError instanceof RateLimitError && attempt < this.retries && apiError.retryAfter) {
@@ -786,7 +794,7 @@ export class OilPriceAPI {
    *
    * Hits `GET /v1/demo/prices` (no API key required) and returns the parsed
    * `{ prices, meta }` envelope. Useful for trying the client without
-   * credentials. Subject to the demo rate limit (~20 requests/hour).
+   * credentials. Current limits are returned by the endpoint.
    *
    * @example
    * ```typescript
@@ -804,7 +812,7 @@ export class OilPriceAPI {
    *
    * Hits `GET /v1/demo/commodities` (no API key required) and returns the parsed
    * `{ commodities, meta }` envelope, where `meta.free_commodities` lists the
-   * codes available on the free demo tier.
+   * codes currently advertised by the demo endpoint.
    *
    * @example
    * ```typescript

--- a/src/resources/streaming.ts
+++ b/src/resources/streaming.ts
@@ -514,7 +514,7 @@ export class StreamingResource {
     options: StreamPricesOptions = {},
     onUpdate?: PriceUpdateHandler,
   ): PriceStreamSubscription {
-    const apiKey = this.client["apiKey"] as string;
+    const apiKey = this.client["requireApiKey"]();
     const sub = new PriceStreamSubscription(this.cableUrl(), apiKey, options, this.wsImpl);
 
     if (onUpdate) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,8 @@ export type RetryStrategy = "exponential" | "linear" | "fixed";
 export interface OilPriceAPIConfig {
   /**
    * Your API key from https://www.oilpriceapi.com
-   * If not provided, reads from OILPRICEAPI_KEY environment variable.
+   * If not provided, reads from OILPRICEAPI_KEY. Keyless clients may call the
+   * public demo methods; authenticated methods fail before making a request.
    */
   apiKey?: string;
 

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -48,6 +48,30 @@ describe("OilPriceAPI", () => {
     }
   });
 
+  it("surfaces a keyless demo 429 as a testable failure", async () => {
+    const saved = process.env.OILPRICEAPI_KEY;
+    delete process.env.OILPRICEAPI_KEY;
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "Demo rate limit exceeded" }), {
+        status: 429,
+        headers: { "Retry-After": "60" },
+      }),
+    );
+    try {
+      const client = new OilPriceAPI({ apiKey: "", retries: 0 });
+
+      await expect(client.getDemoPrices()).rejects.toMatchObject({
+        name: "RateLimitError",
+        statusCode: 429,
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.restoreAllMocks();
+      if (saved === undefined) delete process.env.OILPRICEAPI_KEY;
+      else process.env.OILPRICEAPI_KEY = saved;
+    }
+  });
+
   it("should initialize with valid API key", () => {
     const client = new OilPriceAPI({ apiKey: "test_key" });
     expect(client).toBeInstanceOf(OilPriceAPI);

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,16 +1,50 @@
 import { describe, it, expect, vi } from "vitest";
-import { OilPriceAPI, AuthenticationError } from "../src/index.js";
+import { OilPriceAPI } from "../src/index.js";
 
 describe("OilPriceAPI", () => {
-  it("should throw error if API key is missing", () => {
+  it("allows a keyless demo client but blocks authenticated requests before fetch", async () => {
     const saved = process.env.OILPRICEAPI_KEY;
     delete process.env.OILPRICEAPI_KEY;
+    const fetchSpy = vi.spyOn(global, "fetch");
     try {
-      expect(() => {
-        new OilPriceAPI({ apiKey: "" });
-      }).toThrow("API key required");
+      const client = new OilPriceAPI({ apiKey: "", retries: 0 });
+
+      await expect(client.getLatestPrices()).rejects.toThrow("API key required");
+      expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
-      if (saved) process.env.OILPRICEAPI_KEY = saved;
+      vi.restoreAllMocks();
+      if (saved === undefined) delete process.env.OILPRICEAPI_KEY;
+      else process.env.OILPRICEAPI_KEY = saved;
+    }
+  });
+
+  it("calls the public demo endpoint without an API key or Authorization header", async () => {
+    const saved = process.env.OILPRICEAPI_KEY;
+    delete process.env.OILPRICEAPI_KEY;
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "success",
+          data: {
+            prices: [{ code: "BRENT_CRUDE_USD", price: 80 }],
+            meta: { demo_mode: true },
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    try {
+      const client = new OilPriceAPI({ apiKey: "", retries: 0 });
+
+      const result = await client.getDemoPrices();
+
+      expect(result.prices[0].code).toBe("BRENT_CRUDE_USD");
+      const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers.Authorization).toBeUndefined();
+    } finally {
+      vi.restoreAllMocks();
+      if (saved === undefined) delete process.env.OILPRICEAPI_KEY;
+      else process.env.OILPRICEAPI_KEY = saved;
     }
   });
 

--- a/tests/live-policy.test.ts
+++ b/tests/live-policy.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("live test failure policy", () => {
+  it("never applies the shared authenticated-key 429 skip to keyless demo tests", () => {
+    const source = readFileSync(
+      new URL("./live/demo-endpoints.test.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).not.toContain("skipIfRateLimited");
+    expect(source).not.toMatch(/\bctx\.skip\s*\(/);
+  });
+});

--- a/tests/live/demo-endpoints.test.ts
+++ b/tests/live/demo-endpoints.test.ts
@@ -19,9 +19,7 @@ describe("LIVE demo endpoints", () => {
   let client: OilPriceAPI;
 
   beforeAll(() => {
-    // The demo endpoints ignore auth, but the constructor still requires a key.
-    // Any placeholder works — the demo path does not send/validate it meaningfully.
-    client = new OilPriceAPI({ apiKey: "demo", retries: 1 });
+    client = new OilPriceAPI({ retries: 1 });
   });
 
   it("getDemoPrices() parses the real prices envelope", async (ctx) => {
@@ -29,7 +27,7 @@ describe("LIVE demo endpoints", () => {
       const res = await client.getDemoPrices();
 
       expect(Array.isArray(res.prices)).toBe(true);
-      // The demo tier exposes a fixed set of free commodities (currently 9).
+      // The demo catalogue can grow, so keep this as a compatibility floor.
       expect(res.prices.length).toBeGreaterThanOrEqual(5);
 
       const brent = res.prices.find((p) => p.code === "BRENT_CRUDE_USD");

--- a/tests/live/demo-endpoints.test.ts
+++ b/tests/live/demo-endpoints.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { OilPriceAPI } from "../../src/client.js";
-import { sleep, RATE_LIMIT_DELAY_MS, skipIfRateLimited } from "./helpers.js";
+import { sleep, RATE_LIMIT_DELAY_MS } from "./helpers.js";
 
 describe("LIVE demo endpoints", () => {
   let client: OilPriceAPI;
@@ -22,7 +22,7 @@ describe("LIVE demo endpoints", () => {
     client = new OilPriceAPI({ retries: 1 });
   });
 
-  it("getDemoPrices() parses the real prices envelope", async (ctx) => {
+  it("getDemoPrices() parses the real prices envelope", async () => {
     try {
       const res = await client.getDemoPrices();
 
@@ -39,14 +39,12 @@ describe("LIVE demo endpoints", () => {
 
       expect(res.meta).toBeDefined();
       expect(res.meta.demo_mode).toBe(true);
-    } catch (e) {
-      skipIfRateLimited(e, ctx);
     } finally {
       await sleep(RATE_LIMIT_DELAY_MS);
     }
   });
 
-  it("getDemoCommodities() parses the real commodities envelope", async (ctx) => {
+  it("getDemoCommodities() parses the real commodities envelope", async () => {
     try {
       const res = await client.getDemoCommodities();
 
@@ -61,8 +59,6 @@ describe("LIVE demo endpoints", () => {
       expect(Array.isArray(res.meta.free_commodities)).toBe(true);
       expect(res.meta.free_commodities).toContain("BRENT_CRUDE_USD");
       expect(res.meta.free_commodities).toContain("WTI_USD");
-    } catch (e) {
-      skipIfRateLimited(e, ctx);
     } finally {
       await sleep(RATE_LIMIT_DELAY_MS);
     }

--- a/tests/resources/streaming.test.ts
+++ b/tests/resources/streaming.test.ts
@@ -425,6 +425,20 @@ describe("StreamingResource", () => {
     });
   });
 
+  it("rejects a keyless client before opening a WebSocket", () => {
+    const saved = process.env.OILPRICEAPI_KEY;
+    delete process.env.OILPRICEAPI_KEY;
+    try {
+      const keylessClient = new OilPriceAPI({ apiKey: "" });
+
+      expect(() => makeStream(keylessClient)).toThrow("API key required");
+      expect(MockWebSocket.instances).toHaveLength(0);
+    } finally {
+      if (saved === undefined) delete process.env.OILPRICEAPI_KEY;
+      else process.env.OILPRICEAPI_KEY = saved;
+    }
+  });
+
   it("is exposed as client.stream", () => {
     expect(client.stream).toBeInstanceOf(StreamingResource);
   });


### PR DESCRIPTION
## Decision

Make the published no-auth demo contract true without weakening authenticated paths, and make its hosted live test fail on public demo errors. This does not publish a package or change API behavior.

## Reproduced defects

The npm `oilpriceapi@1.1.0` artifact documents `getDemoPrices()` as usable without credentials, but `new OilPriceAPI()` throws before the demo method can run. The exact registry artifact failed before making any request; the same artifact worked only when supplied a fake `"demo"` key.

Red-team then found that the keyless live suite caught every error and called `skipIfRateLimited()`. That helper is explicitly justified only for contention on the shared authenticated CI key. A public demo 429 could therefore skip both tests and report a zero-assertion green job.

## Change

- allow construction without an API key for the two public demo methods
- fail authenticated HTTP calls locally with `MISSING_API_KEY` before `fetch`
- fail streaming locally before a WebSocket is opened
- make the live demo suite actually run without a placeholder key
- remove the shared-key 429 skip path from the keyless demo suite; demo 429 and every other request/assertion error now fail the job
- add a default-gate policy regression that rejects any future `skipIfRateLimited`/`ctx.skip` use in the keyless source
- add a direct client regression proving a no-auth demo 429 surfaces as one `RateLimitError`
- remove mutable exact demo-limit/tier wording from generated API comments

## Red / green proof

Constructor contract red on current `main`: **3 failures / 22 targeted tests**, all at constructor time.

False-green policy regression red on prior PR head `9f1c6027ace4dea8a08ed55118623fa39f96f76a`: **1/1 failed** because the keyless suite imported `skipIfRateLimited`.

Green at exact head `609b21d4747412a15e75374f0ddf77abfa96dda4` locally:

- targeted policy + client: **6/6**
- full unit suite: **462 passed, 1 skipped**
- live keyless production demo: **2/2**, no skip path
- executable snippet fixtures: **6/6**; manifest tests **4/4**
- TypeScript ESM/CJS build, storefront claims, secret scan, ESLint, and diff check: clean (10 inherited ESLint warnings, 0 errors)
- packed-tarball clean install from the prior code head: live demo returned 34 rows; authenticated call without a key failed locally. The final commit changes tests only, not packed code.

Hosted live and Node 18/20/22/24 checks must be green at exact head before approval. No npm release, deploy, API mutation, email, SMS, or customer action occurred. Keep SDK promotion held until this is reviewed, merged, released, and the exact registry artifact is re-smoked.
