### PR TITLE
Release Node SDK v1.2.0

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   live:
     name: Live API contract tests
@@ -20,6 +23,8 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,14 +27,36 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify release tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]; then
+            echo "::error::Release tag $RELEASE_TAG does not match package version $PACKAGE_VERSION"
+            exit 1
+          fi
+
+      - name: Audit dependencies
+        run: npm audit --audit-level=low
+
       - name: TypeScript build check
         run: npx tsc --noEmit
 
       - name: Run tests
         run: npm test
 
+      - name: Lint
+        run: npm run lint
+
+      - name: Validate public storefront claims
+        run: npm run storefront:check
+
       - name: Build
         run: npm run build
+
+      - name: Install and exercise the exact package tarball
+        run: npm run smoke:package
 
       - name: Build signed snippet manifest
         run: npm run snippets:build -- --source-commit "$GITHUB_SHA"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit dependencies
+        run: npm audit --audit-level=low
+
       - name: TypeScript build check
         run: npx tsc --noEmit
 
@@ -34,7 +37,7 @@ jobs:
         run: npm run storefront:check
 
       - name: ESLint
-        run: npx eslint src/
+        run: npm run lint
 
   test:
     name: Test (Node ${{ matrix.node-version }})
@@ -94,3 +97,20 @@ jobs:
           npx tsc --noEmit -p tsconfig.snippets.json
           npm run snippets:fixtures
           npm run snippets:build -- --source-commit "$GITHUB_SHA"
+
+  clean-install:
+    name: Exact package ESM and CJS smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Pack, install, import, and call the keyless production demo
+        run: npm run smoke:package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -49,6 +54,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v7
@@ -82,6 +89,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js 18
         uses: actions/setup-node@v7
@@ -103,6 +112,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-08-11
+
+### Added
+
+- Allow clients without credentials to call the public demo price and
+  commodity methods without sending an `Authorization` header.
+- Export normalized authentication, authorization, validation, rate-limit,
+  quota, server, and timeout error classes with stable recovery metadata.
+
+### Fixed
+
+- Fail authenticated HTTP and streaming calls locally with `MISSING_API_KEY`
+  instead of constructing an invalid request.
+- Validate the dynamic demo catalogue by contract and make production 429s fail
+  the live release gate rather than silently skipping the check.
+- Update runtime, build, lint, type, and GitHub Actions dependencies and resolve
+  all known npm audit findings at release time.
+
 ## [1.1.0] - 2026-07-19
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.21.0"
@@ -1671,16 +1671,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chai": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Official Node.js SDK for source-timestamped OilPriceAPI energy data",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -29,7 +29,8 @@
     "snippets:build": "node scripts/generate-snippet-manifest.mjs --output artifacts/snippets/oilpriceapi-node-snippets-v1.json",
     "snippets:fixtures": "node scripts/run-snippet-fixtures.mjs",
     "snippets:check": "tsc --noEmit -p tsconfig.snippets.json && npm run snippets:fixtures && vitest run tests/snippet-manifest.test.ts",
-    "lint": "eslint src/",
+    "lint": "eslint src/ --max-warnings=0",
+    "smoke:package": "./scripts/clean-install-smoke.sh",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:live": "vitest run --config vitest.live.config.ts",

--- a/scripts/clean-install-smoke.sh
+++ b/scripts/clean-install-smoke.sh
@@ -9,6 +9,7 @@ version="$(node -p "require('$root/package.json').version")"
 tarball="$scratch/oilpriceapi-$version.tgz"
 
 cd "$root"
+npm run build
 npm pack --pack-destination "$scratch" >/dev/null
 test -f "$tarball"
 

--- a/scripts/clean-install-smoke.sh
+++ b/scripts/clean-install-smoke.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+version="$(node -p "require('$root/package.json').version")"
+tarball="$scratch/oilpriceapi-$version.tgz"
+
+cd "$root"
+npm pack --pack-destination "$scratch" >/dev/null
+test -f "$tarball"
+
+mkdir "$scratch/consumer"
+cd "$scratch/consumer"
+npm init -y >/dev/null
+npm install --ignore-scripts --no-audit --no-fund "$tarball" >/dev/null
+
+EXPECTED_VERSION="$version" node --input-type=module <<'NODE'
+import { OilPriceAPI, SDK_VERSION } from "oilpriceapi";
+
+if (SDK_VERSION !== process.env.EXPECTED_VERSION) {
+  throw new Error(`ESM version mismatch: ${SDK_VERSION}`);
+}
+const response = await new OilPriceAPI({ apiKey: "", retries: 0 }).getDemoPrices();
+const brent = response.prices.find((price) => price.code === "BRENT_CRUDE_USD");
+if (!brent || !Number.isFinite(brent.price) || !brent.updated_at) {
+  throw new Error("ESM demo response failed the price integrity contract");
+}
+NODE
+
+sleep 1
+
+EXPECTED_VERSION="$version" node --input-type=commonjs <<'NODE'
+const { OilPriceAPI, SDK_VERSION } = require("oilpriceapi");
+
+if (SDK_VERSION !== process.env.EXPECTED_VERSION) {
+  throw new Error(`CJS version mismatch: ${SDK_VERSION}`);
+}
+new OilPriceAPI({ apiKey: "", retries: 0 }).getDemoPrices().then((response) => {
+  const wti = response.prices.find((price) => price.code === "WTI_USD");
+  if (!wti || !Number.isFinite(wti.price) || !wti.updated_at) {
+    throw new Error("CJS demo response failed the price integrity contract");
+  }
+});
+NODE
+
+echo "oilpriceapi@$version packed ESM/CJS production smoke passed"

--- a/src/client.ts
+++ b/src/client.ts
@@ -43,6 +43,10 @@ import { StreamingResource } from "./resources/streaming.js";
 import { SubscriptionsResource } from "./resources/subscriptions.js";
 import { WellProductionResource } from "./resources/well-production.js";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
  * Raw HTTP response wrapper.
  *
@@ -256,7 +260,7 @@ export class OilPriceAPI {
   /**
    * Log debug messages if debug mode is enabled
    */
-  private log(message: string, data?: any): void {
+  private log(message: string, data?: unknown): void {
     if (this.debug) {
       const timestamp = new Date().toISOString();
       console.log(`[OilPriceAPI ${timestamp}] ${message}`, data || "");
@@ -288,7 +292,7 @@ export class OilPriceAPI {
   /**
    * Determine if error is retryable
    */
-  private isRetryable(error: any): boolean {
+  private isRetryable(error: unknown): boolean {
     // Retry on network errors
     if (error instanceof TypeError && error.message.includes("fetch")) {
       return true;
@@ -321,25 +325,27 @@ export class OilPriceAPI {
    * envelope shapes as well as the generic `{ data }` fallback used by resource
    * mutations, alerts, webhooks, etc.
    */
-  private shapeResponseData<T>(responseData: any): T {
+  private shapeResponseData<T>(responseData: unknown): T {
     // Handle different response structures
     // Latest endpoint: { status, data: { price, ... } }
     // Historical endpoint: { status, data: { prices: [...] } }
-    if (responseData.status === "success" && responseData.data) {
-      if (responseData.data.prices) {
+    if (isRecord(responseData) && responseData.status === "success" && isRecord(responseData.data)) {
+      if (Array.isArray(responseData.data.prices)) {
         // Historical endpoint - return prices array
         this.log(`Returning ${responseData.data.prices.length} prices`);
         return responseData.data.prices as T;
       } else if (responseData.data.price !== undefined) {
         // Latest endpoint - wrap single price in array
         this.log("Returning single price (wrapped in array)");
-        return [responseData.data] as T;
+        return [responseData.data] as unknown as T;
       }
     }
 
     // Fallback - return data as-is (used by resource mutations, alerts, webhooks, etc.)
     this.log("Returning data as-is");
-    return (responseData.data !== undefined ? responseData.data : responseData) as T;
+    return (isRecord(responseData) && responseData.data !== undefined
+      ? responseData.data
+      : responseData) as T;
   }
 
   /**
@@ -465,11 +471,12 @@ export class OilPriceAPI {
           }
 
           // Parse successful response
-          const responseData: any = JSON.parse(responseText);
+          const responseData: unknown = JSON.parse(responseText);
+          const responseObject = isRecord(responseData) ? responseData : undefined;
 
           this.log("Response data received", {
-            status: responseData.status,
-            hasData: !!responseData.data,
+            status: responseObject?.status,
+            hasData: responseObject?.data !== undefined,
           });
 
           return {
@@ -855,9 +862,9 @@ export class OilPriceAPI {
         throw errorFromResponse(response, body);
       }
 
-      const parsed: any = JSON.parse(await response.text());
+      const parsed: unknown = JSON.parse(await response.text());
       // Demo envelope is { status: "success", data: { ... } }.
-      return (parsed.data !== undefined ? parsed.data : parsed) as T;
+      return (isRecord(parsed) && parsed.data !== undefined ? parsed.data : parsed) as T;
     } catch (error) {
       if (error instanceof Error && error.name === "AbortError") {
         throw new TimeoutError("Request timeout", this.timeout);

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,11 @@ export type {
   CreateAlertParams,
   UpdateAlertParams,
   AlertOperator,
+  AlertTrigger,
+  AlertAnalyticsEntry,
+  AlertAnalyticsPagination,
+  AlertAnalyticsHistory,
+  WebhookTestResponse as AlertWebhookTestResponse,
 } from "./resources/alerts.js";
 export type {
   FuturesPrice,

--- a/src/resources/alerts.ts
+++ b/src/resources/alerts.ts
@@ -109,6 +109,38 @@ export interface WebhookTestResponse {
   error?: string;
 }
 
+/** A record returned by the deprecated trigger-history endpoint. */
+export type AlertTrigger = Record<string, unknown>;
+
+/** One triggered analytics alert returned by analytics history. */
+export interface AlertAnalyticsEntry {
+  id: string | number;
+  name: string;
+  commodity_code: string;
+  analytics_type: string;
+  analytics_period: string | null;
+  analytics_config: Record<string, unknown> | null;
+  condition: string;
+  trigger_count: number;
+  last_triggered_at: string;
+  cooldown_minutes: number;
+  enabled: boolean;
+  metadata: Record<string, unknown> | null;
+}
+
+/** Pagination metadata returned with analytics history. */
+export interface AlertAnalyticsPagination {
+  page: number;
+  per_page: number;
+  total: number;
+}
+
+/** Typed response from the analytics-history endpoint. */
+export interface AlertAnalyticsHistory {
+  triggered_alerts: AlertAnalyticsEntry[];
+  pagination: AlertAnalyticsPagination;
+}
+
 /**
  * Price Alerts Resource
  *
@@ -520,8 +552,10 @@ export class AlertsResource {
    * });
    * ```
    */
-  async triggers(): Promise<any[]> {
-    const response = await this.client["request"]<any[] | { triggers: any[] }>(
+  async triggers(): Promise<AlertTrigger[]> {
+    const response = await this.client["request"]<
+      AlertTrigger[] | { triggers: AlertTrigger[] }
+    >(
       "/v1/alerts/triggers",
       {},
     );
@@ -545,7 +579,7 @@ export class AlertsResource {
    * console.log(`Success rate: ${analytics.success_rate}%`);
    * ```
    */
-  async analyticsHistory(): Promise<any> {
-    return this.client["request"]<any>("/v1/alerts/analytics_history", {});
+  async analyticsHistory(): Promise<AlertAnalyticsHistory> {
+    return this.client["request"]<AlertAnalyticsHistory>("/v1/alerts/analytics_history", {});
   }
 }

--- a/src/resources/alerts.ts
+++ b/src/resources/alerts.ts
@@ -565,8 +565,8 @@ export class AlertsResource {
   /**
    * Get alert analytics history
    *
-   * Returns historical analytics data for alerts including trigger frequency,
-   * success rates, and response times.
+   * Returns triggered analytics alerts and pagination metadata. The total
+   * number of matching alerts is available as `pagination.total`.
    *
    * @returns Analytics history data
    *
@@ -575,8 +575,8 @@ export class AlertsResource {
    * @example
    * ```typescript
    * const analytics = await client.alerts.analyticsHistory();
-   * console.log(`Total triggers: ${analytics.total_triggers}`);
-   * console.log(`Success rate: ${analytics.success_rate}%`);
+   * console.log(`Triggered alerts: ${analytics.pagination.total}`);
+   * console.log(analytics.triggered_alerts[0]?.last_triggered_at);
    * ```
    */
   async analyticsHistory(): Promise<AlertAnalyticsHistory> {

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,7 +7,7 @@
  * - X-Client-Version header
  * - Package.json (should match)
  */
-export const SDK_VERSION = "1.1.0";
+export const SDK_VERSION = "1.2.0";
 
 /**
  * SDK identifier used in User-Agent and X-Api-Client headers

--- a/tests/release-readiness.test.ts
+++ b/tests/release-readiness.test.ts
@@ -20,11 +20,13 @@ describe("release readiness", () => {
       scripts: Record<string, string>;
     };
     const workflow = read(".github/workflows/publish.yml");
+    const smokeScript = read("scripts/clean-install-smoke.sh");
 
     expect(packageJson.scripts.lint).toContain("--max-warnings=0");
     expect(packageJson.scripts["smoke:package"]).toBe("./scripts/clean-install-smoke.sh");
     expect(workflow).toContain("Verify release tag matches package version");
     expect(workflow).toContain("npm audit --audit-level=low");
     expect(workflow).toContain("npm run smoke:package");
+    expect(smokeScript).toMatch(/npm run build[\s\S]*npm pack/);
   });
 });

--- a/tests/release-readiness.test.ts
+++ b/tests/release-readiness.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const read = (path: string): string => readFileSync(path, "utf8");
@@ -28,5 +28,15 @@ describe("release readiness", () => {
     expect(workflow).toContain("npm audit --audit-level=low");
     expect(workflow).toContain("npm run smoke:package");
     expect(smokeScript).toMatch(/npm run build[\s\S]*npm pack/);
+  });
+
+  it("does not persist checkout credentials in repository workflows", () => {
+    for (const name of readdirSync(".github/workflows").filter((file) => file.endsWith(".yml"))) {
+      const workflow = read(`.github/workflows/${name}`);
+      const checkoutCount = workflow.match(/actions\/checkout@/g)?.length ?? 0;
+      const hardenedCount = workflow.match(/persist-credentials: false/g)?.length ?? 0;
+
+      expect(hardenedCount, name).toBe(checkoutCount);
+    }
   });
 });

--- a/tests/release-readiness.test.ts
+++ b/tests/release-readiness.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string): string => readFileSync(path, "utf8");
+
+describe("release readiness", () => {
+  it("keeps package, runtime, and changelog versions aligned", () => {
+    const packageJson = JSON.parse(read("package.json")) as { version: string };
+    const versionSource = read("src/version.ts");
+    const changelog = read("CHANGELOG.md");
+    const firstRelease = changelog.match(/^## \[([^\]]+)\]/m);
+
+    expect(packageJson.version).toBe("1.2.0");
+    expect(versionSource).toContain(`SDK_VERSION = "${packageJson.version}"`);
+    expect(firstRelease?.[1]).toBe(packageJson.version);
+  });
+
+  it("gates publication on audit, exact tag, and packed ESM/CJS imports", () => {
+    const packageJson = JSON.parse(read("package.json")) as {
+      scripts: Record<string, string>;
+    };
+    const workflow = read(".github/workflows/publish.yml");
+
+    expect(packageJson.scripts.lint).toContain("--max-warnings=0");
+    expect(packageJson.scripts["smoke:package"]).toBe("./scripts/clean-install-smoke.sh");
+    expect(workflow).toContain("Verify release tag matches package version");
+    expect(workflow).toContain("npm audit --audit-level=low");
+    expect(workflow).toContain("npm run smoke:package");
+  });
+});

--- a/tests/resources/alerts.test.ts
+++ b/tests/resources/alerts.test.ts
@@ -4,6 +4,7 @@ import type {
   PriceAlert,
   CreateAlertParams,
   UpdateAlertParams,
+  AlertAnalyticsHistory,
 } from "../../src/resources/alerts.js";
 
 describe("AlertsResource", () => {
@@ -612,6 +613,37 @@ describe("AlertsResource", () => {
       await expect(client.alerts.test("")).rejects.toThrow(
         "Alert ID must be a non-empty string",
       );
+    });
+  });
+
+  describe("analyticsHistory()", () => {
+    it("returns triggered alerts and pagination from the current API contract", async () => {
+      const mockResponse: AlertAnalyticsHistory = {
+        triggered_alerts: [
+          {
+            id: 42,
+            name: "Brent z-score",
+            commodity_code: "BRENT_CRUDE_USD",
+            analytics_type: "z_score",
+            analytics_period: "30d",
+            analytics_config: { threshold: 2 },
+            condition: "z-score exceeds 2",
+            trigger_count: 3,
+            last_triggered_at: "2026-08-11T10:00:00Z",
+            cooldown_minutes: 60,
+            enabled: true,
+            metadata: null,
+          },
+        ],
+        pagination: { page: 1, per_page: 20, total: 1 },
+      };
+      const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockResponse);
+
+      const result = await client.alerts.analyticsHistory();
+
+      expect(result.pagination.total).toBe(1);
+      expect(result.triggered_alerts[0].analytics_type).toBe("z_score");
+      expect(requestSpy).toHaveBeenCalledWith("/v1/alerts/analytics_history", {});
     });
   });
 });


### PR DESCRIPTION
## Summary
- publish normalized SDK errors and the keyless demo contract as v1.2.0
- eliminate the remaining dependency advisory and make lint warnings blocking
- verify tag/version alignment and install the exact packed tarball in clean ESM and CJS consumers before npm publication
- add typed alert analytics responses in place of public `any` return values

## Red-green evidence
- RED: release contract failed 2/2 on the old 1.1.0 metadata and missing artifact gates; `npm audit` reported the brace-expansion advisory; ESLint reported 10 explicit-any warnings
- GREEN: 464 passed, 1 intentional skip; build and snippet fixtures 6/6; zero-warning lint; zero npm advisories; exact tarball ESM/CJS production demo smoke passed

## Release gate
Do not publish until this PR and its hosted unit, lint, audit, clean-install, and live checks pass at the exact head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed alert trigger and analytics-history responses.
  * Exported alert, analytics, pagination, history, and webhook response types.
  * Added safer handling for unexpected API and demo response formats.

* **Bug Fixes**
  * Improved validation of response data and missing-key failures.
  * Strengthened production rate-limit and demo catalogue checks.

* **Chores**
  * Updated the SDK to version 1.2.0.
  * Enhanced release validation, dependency auditing, linting, and package smoke tests.
  * Added changelog documentation for the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->