### PR TITLE
Fix generated and packed SDK claim drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-08-11
+
+### Fixed
+
+- Remove stale plan-price, quota-exemption, cadence, cost-comparison, and
+  generic real-time claims from generated docs and published package comments.
+- Discover authored docs and package source recursively, then validate the
+  exact packed npm artifact so a generated declaration cannot bypass the
+  reviewed product-claim contract.
+
 ## [1.2.0] - 2026-08-11
 
 ### Added

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OilPriceAPI Node.js SDK - Real-time Oil & Commodity Price Data</title>
-    <meta name="description" content="Official Node.js SDK for real-time and historical oil, gas, and commodity price data. 98% less cost than Bloomberg Terminal. Free tier available.">
+    <title>OilPriceAPI Node.js SDK - Source-Timestamped Commodity Data</title>
+    <meta name="description" content="Official Node.js SDK for source-timestamped current and historical oil, gas, and commodity data.">
     <meta name="keywords" content="nodejs oil prices, commodity data javascript, oil price api, node energy data, brent crude node, wti nodejs sdk">
 
     <!-- Open Graph -->
     <meta property="og:title" content="OilPriceAPI Node.js SDK">
-    <meta property="og:description" content="Real-time oil & commodity price data for Node.js developers">
+    <meta property="og:description" content="Source-timestamped oil and commodity data for Node.js developers">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://oilpriceapi.github.io/nodejs-sdk/">
 
@@ -209,12 +209,12 @@
         <!-- Hero -->
         <div class="hero">
             <h1>⚡ OilPriceAPI Node.js SDK</h1>
-            <p class="tagline">Real-time oil & commodity price data for Node.js developers</p>
-            <p>Professional-grade API at <strong>98% less cost</strong> than Bloomberg Terminal</p>
+            <p class="tagline">Source-timestamped oil and commodity data for Node.js developers</p>
+            <p>Typed responses preserve the source and observation time needed to interpret each value.</p>
 
             <div class="cta-buttons">
-                <a href="https://www.npmjs.com/package/@oilpriceapi/client" class="btn btn-primary">Install from npm</a>
-                <a href="https://oilpriceapi.com/auth/signup" class="btn btn-secondary">Get Free API Key</a>
+                <a href="https://www.npmjs.com/package/oilpriceapi" class="btn btn-primary">Install from npm</a>
+                <a href="https://oilpriceapi.com/auth/signup" class="btn btn-secondary">Create API Key</a>
             </div>
 
             <pre><code>npm install @oilpriceapi/client</code></pre>
@@ -239,8 +239,8 @@
         <!-- Features -->
         <div class="features">
             <div class="feature-card">
-                <h3>⚡ Real-Time Prices</h3>
-                <p>Latest spot prices for Brent, WTI, Natural Gas, Coal, and more. Updated every 15 minutes.</p>
+                <h3>⚡ Current Prices</h3>
+                <p>Latest available spot prices for Brent, WTI, Natural Gas, and Coal, with API-provided source timestamps.</p>
             </div>
 
             <div class="feature-card">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.21.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Official Node.js SDK for source-timestamped OilPriceAPI energy data",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/scripts/clean-install-smoke.sh
+++ b/scripts/clean-install-smoke.sh
@@ -17,6 +17,8 @@ mkdir "$scratch/consumer"
 cd "$scratch/consumer"
 npm init -y >/dev/null
 npm install --ignore-scripts --no-audit --no-fund "$tarball" >/dev/null
+node "$root/scripts/validate-storefront-claims.mjs" \
+  --package-root "$scratch/consumer/node_modules/oilpriceapi"
 
 EXPECTED_VERSION="$version" node --input-type=module <<'NODE'
 import { OilPriceAPI, SDK_VERSION } from "oilpriceapi";

--- a/scripts/validate-storefront-claims.mjs
+++ b/scripts/validate-storefront-claims.mjs
@@ -1,39 +1,84 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, extname, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const surfaces = ["README.md", "package.json"];
-const blocked = [
-  /\breal[ -]?time\b/i,
-  /\b(?:110|200|500)\+\s+(?:commodit|endpoint|tool)/i,
-  /\b2m\+?\s+api requests/i,
-  /\b(?:every|updated|refresh(?:ed)?)\s+(?:in\s+)?5 minutes\b/i,
-  /\b(?:99\.\d+%|fortune 500|trading[- ]grade)\b/i,
-  /\b(?:1,000|100)\s+requests?(?:\/month|\s+per month|\s+\(lifetime\))/i,
-  /\bunlimited\s+(?:history|webhooks?|requests?|commodit)/i,
-];
+const defaultRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const contract = "https://api.oilpriceapi.com/product-facts.json";
+const blocked = [
+  ["real-time claim", /\breal[ -]?time\b/i],
+  ["fixed catalog total", /\b\d+\+\s+(?:commodit|endpoint|tool|api)/i],
+  ["fixed traffic total", /\b2m\+?\s+api requests/i],
+  ["fixed update cadence", /\b(?:every|updated|refresh(?:ed)?)\s+(?:in\s+)?\d+\s+minutes\b/i],
+  ["uptime or SLA", /\b\d+(?:\.\d+)?%\s+uptime\b|\bSLA\b/i],
+  ["price comparison", /\bbloomberg\b|\b\d+(?:\.\d+)?%\s+less\s+cost\b/i],
+  ["unreviewed plan name", /\bprofessional\+?\b|\bstarter plan\b|\bscale tier\b/i],
+  ["unreviewed plan price", /\$\d+(?:\.\d+)?\s*(?:\/|per\s+)(?:mo(?:nth)?|year)\b/i],
+  [
+    "fixed allowance",
+    /\b(?:1,000|100)\s+requests?(?:\/month|\s+per month|\s+\(lifetime\))/i,
+  ],
+  ["quota promise", /\bdoes\s+not\s+consume.{0,40}\bquota\b|\bunlimited\s+(?:history|webhooks?|requests?|commodit)/i],
+  ["free-tier claim", /\bfree\s+tier\b|\bfree\s+api\s+key\b/i],
+  ["free endpoint claim", /\b(?:endpoint|resource|api)\s+is\s+free\b|\bincluded\s+in\s+all\s+tiers\b/i],
+  ["fixed query allowance", /\b\d[\d,]*\s+(?:station\s+)?queries?\s*(?:\/|per\s+)month\b/i],
+  [
+    "fixed demo rate",
+    /\b\d+\s+(?:requests?|reqs?\.?)\s*(?:(?:per|an?)\s+|\/\s*)(?:minutes?|mins?|hours?|hrs?|days?)\b/i,
+  ],
+];
 
-export function validateStorefront() {
+function walkFiles(directory, extensions) {
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(path, extensions));
+    } else if (extensions.has(extname(entry.name))) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+export function discoverStorefrontSurfaces(baseRoot = defaultRoot) {
+  const files = [resolve(baseRoot, "README.md"), resolve(baseRoot, "package.json")];
+  for (const [directory, extensions] of [
+    ["docs", new Set([".html", ".md"])],
+    ["src", new Set([".ts"])],
+  ]) {
+    files.push(...walkFiles(resolve(baseRoot, directory), extensions));
+  }
+  return files.sort();
+}
+
+function claimFailures(baseRoot, files) {
   const failures = [];
-  for (const relativePath of surfaces) {
-    const contents = readFileSync(resolve(root, relativePath), "utf8");
-    for (const pattern of blocked) {
-      if (pattern.test(contents)) {
-        failures.push(`${relativePath}: blocked claim matched ${pattern}`);
+  for (const path of files) {
+    const contents = readFileSync(path, "utf8");
+    for (const [label, pattern] of blocked) {
+      const match = contents.match(pattern);
+      if (match) {
+        failures.push(`${relative(baseRoot, path)}: ${label} ${JSON.stringify(match[0])}`);
       }
     }
   }
+  return failures;
+}
 
-  const readme = readFileSync(resolve(root, "README.md"), "utf8");
+function requireContractLink(baseRoot, failures) {
+  const readme = readFileSync(resolve(baseRoot, "README.md"), "utf8");
   if (!readme.includes(contract)) {
     failures.push("README.md: reviewed product-facts contract is not linked");
   }
+}
 
-  const packageJson = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
-  const versionSource = readFileSync(resolve(root, "src/version.ts"), "utf8");
+export function validateStorefront(baseRoot = defaultRoot) {
+  const failures = claimFailures(baseRoot, discoverStorefrontSurfaces(baseRoot));
+  requireContractLink(baseRoot, failures);
+
+  const packageJson = JSON.parse(readFileSync(resolve(baseRoot, "package.json"), "utf8"));
+  const versionSource = readFileSync(resolve(baseRoot, "src/version.ts"), "utf8");
   const versionMatch = versionSource.match(/SDK_VERSION = "([^"]+)"/);
   if (!versionMatch || packageJson.version !== versionMatch[1]) {
     failures.push("package version differs between package.json and src/version.ts");
@@ -41,10 +86,31 @@ export function validateStorefront() {
   return failures;
 }
 
+export function validatePackage(packageRoot) {
+  const files = [resolve(packageRoot, "README.md"), resolve(packageRoot, "package.json")];
+  files.push(...walkFiles(resolve(packageRoot, "dist"), new Set([".js", ".ts", ".json"])));
+  const failures = claimFailures(packageRoot, files);
+  requireContractLink(packageRoot, failures);
+
+  const packageJson = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8"));
+  const versionSource = readFileSync(resolve(packageRoot, "dist/version.js"), "utf8");
+  const versionMatch = versionSource.match(/SDK_VERSION\s*=\s*"([^"]+)"/);
+  if (!versionMatch || packageJson.version !== versionMatch[1]) {
+    failures.push("package version differs between package.json and dist/version.js");
+  }
+  return failures;
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const failures = validateStorefront();
+  const packageArg = process.argv.indexOf("--package-root");
+  const packageRoot = packageArg >= 0 ? process.argv[packageArg + 1] : undefined;
+  const failures = packageRoot ? validatePackage(resolve(packageRoot)) : validateStorefront();
   if (failures.length) {
     throw new Error(failures.join("\n"));
   }
-  console.log(`validated ${surfaces.length} Node storefront surfaces`);
+  console.log(
+    packageRoot
+      ? "validated exact packed Node artifact claims"
+      : `validated ${discoverStorefrontSurfaces().length} Node public surfaces`,
+  );
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -191,9 +191,10 @@ export class OilPriceAPI {
   public readonly raw: RawResource;
 
   /**
-   * Real-time price streaming resource (WebSocket / ActionCable).
+   * Price streaming resource (WebSocket / ActionCable).
    *
-   * Streaming requires a Professional plan ($99/mo) or higher.
+   * Streaming availability depends on account entitlement. Review current
+   * access at https://www.oilpriceapi.com/pricing.
    */
   public readonly stream: StreamingResource;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Official Node.js SDK for Oil Price API
  *
- * Get real-time and historical oil & commodity prices in your Node.js applications.
+ * Get source-timestamped current and historical commodity data in Node.js applications.
  *
  * @packageDocumentation
  */

--- a/src/resources/bunker-fuels.ts
+++ b/src/resources/bunker-fuels.ts
@@ -269,8 +269,8 @@ export class BunkerFuelsResource {
   /**
    * Get all current bunker fuel prices
    *
-   * Returns prices for all tracked ports, keyed by port code. Requires a
-   * Professional plan or above.
+   * Returns available port prices keyed by port code. Access depends on the
+   * account's current entitlement; see https://www.oilpriceapi.com/pricing.
    *
    * @returns All-ports bunker prices
    *

--- a/src/resources/diesel.ts
+++ b/src/resources/diesel.ts
@@ -133,8 +133,8 @@ export class DieselResource {
   /**
    * Get average diesel price for a US state
    *
-   * Returns EIA state-level average diesel price. This endpoint is free
-   * and included in all tiers.
+   * Returns the available EIA state-level average diesel price and its source
+   * timestamp. Current access is determined by the API.
    *
    * @param state - Two-letter US state code (e.g., "CA", "TX", "NY")
    * @returns State average diesel price
@@ -170,11 +170,9 @@ export class DieselResource {
    *
    * Returns station-level diesel prices within specified radius using Google Maps data.
    *
-   * **Pricing:** Included in paid tiers:
-   * - Exploration: 100 station queries/month
-   * - Starter: 500 station queries/month
-   * - Professional: 2,000 station queries/month
-   * - Business: 5,000 station queries/month
+   * Station-level access and allowances depend on the account's current
+   * entitlement. Review https://www.oilpriceapi.com/pricing and the API's
+   * response metadata instead of relying on an SDK-bundled allowance.
    *
    * **Caching:** Results are cached for 24 hours to minimize costs.
    *

--- a/src/resources/streaming.ts
+++ b/src/resources/streaming.ts
@@ -1,13 +1,14 @@
 /**
  * WebSocket Streaming Resource
  *
- * Real-time price streaming via the OilPriceAPI ActionCable endpoint
+ * Price updates streamed through the OilPriceAPI ActionCable endpoint
  * (`wss://api.oilpriceapi.com/cable`).
  *
- * Streaming is a **Professional plan ($99/mo) or higher** feature. Connections
- * authenticate with your API key and subscribe to the `EnergyPricesChannel`,
- * which pushes an initial `welcome` snapshot followed by live `price_update`
- * and (for drilling-tier accounts) `rig_count_update` messages.
+ * Streaming availability depends on account entitlement; review
+ * https://www.oilpriceapi.com/pricing. Connections authenticate with your API
+ * key and subscribe to the `EnergyPricesChannel`, which pushes an initial
+ * `welcome` snapshot followed by `price_update` and, for eligible accounts,
+ * `rig_count_update` messages.
  *
  * The implementation speaks the raw ActionCable JSON subprotocol over the
  * `ws` package: it performs the `welcome` -> `subscribe` ->
@@ -112,7 +113,7 @@ export interface WelcomeMessage {
 }
 
 /**
- * Rig-count update broadcast (drilling / Professional+ accounts).
+ * Rig-count update broadcast for accounts with drilling access.
  */
 export interface RigCountUpdateMessage {
   type: "rig_count_update";
@@ -319,8 +320,8 @@ export class PriceStreamSubscription extends EventEmitter {
       this.emit(
         "error",
         new Error(
-          "WebSocket subscription rejected. Streaming requires a Professional " +
-            "plan ($99/mo) or higher and a valid API key.",
+          "WebSocket subscription rejected. Confirm the API key and streaming " +
+            "entitlement at https://www.oilpriceapi.com/pricing.",
         ),
       );
       return;
@@ -449,7 +450,7 @@ export class PriceStreamSubscription extends EventEmitter {
 }
 
 /**
- * Streaming resource — entry point for real-time price subscriptions.
+ * Streaming resource: entry point for price-update subscriptions.
  *
  * Accessed via `client.stream`.
  */
@@ -480,7 +481,7 @@ export class StreamingResource {
   }
 
   /**
-   * Open a real-time price stream over the `EnergyPricesChannel`.
+   * Open a price-update stream over the `EnergyPricesChannel`.
    *
    * Returns a {@link PriceStreamSubscription} handle (an `EventEmitter`) you
    * can attach further listeners to and `.close()` when done. The optional

--- a/src/resources/subscriptions.ts
+++ b/src/resources/subscriptions.ts
@@ -6,8 +6,8 @@
  * Phase 2). Designed for autonomous agents (MCP, schedulers, bots) that want
  * change notifications without holding an open connection.
  *
- * The poll endpoint (`events`) does NOT consume the monthly request quota and
- * has its own generous rate-limit lane, so agents can poll frequently.
+ * The poll endpoint (`events`) returns applicable limit guidance from the API;
+ * callers should use that response metadata to choose a polling interval.
  */
 
 import type { OilPriceAPI } from "../client.js";
@@ -203,7 +203,7 @@ export function intervalToSeconds(interval: SubscriptionInterval | undefined): n
  *
  * const client = new OilPriceAPI({ apiKey: 'your_key' });
  *
- * // Create a watch that evaluates Brent + WTI every 5 minutes
+ * // Create a watch using the API-supported `5m` interval
  * const watch = await client.subscriptions.create({
  *   name: 'Crude desk',
  *   codes: ['BRENT_CRUDE_USD', 'WTI_USD'],
@@ -327,7 +327,7 @@ export class SubscriptionsResource {
    * Poll for events emitted by your watches.
    *
    * Returns events with `seq` greater than the supplied cursor, ordered
-   * ascending. This endpoint does NOT consume the monthly request quota.
+   * ascending. Current limits are determined by the API and account.
    *
    * @param options - Cursor (`since`), optional `watchId`, and `limit`.
    * @returns The next cursor, a `has_more` flag, and the events.

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -1,7 +1,7 @@
 /**
  * Webhooks Resource
  *
- * Manage webhook endpoints for real-time event notifications.
+ * Manage webhook endpoints for event notifications.
  */
 
 import type { OilPriceAPI } from "../client.js";
@@ -135,7 +135,7 @@ export interface WebhookEvent {
 /**
  * Webhooks Resource
  *
- * Manage webhook endpoints for real-time notifications about price changes,
+ * Manage webhook endpoints for notifications about price changes,
  * alerts, and other events.
  *
  * @example

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,7 +7,7 @@
  * - X-Client-Version header
  * - Package.json (should match)
  */
-export const SDK_VERSION = "1.2.0";
+export const SDK_VERSION = "1.2.1";
 
 /**
  * SDK identifier used in User-Agent and X-Api-Client headers

--- a/tests/release-readiness.test.ts
+++ b/tests/release-readiness.test.ts
@@ -10,7 +10,7 @@ describe("release readiness", () => {
     const changelog = read("CHANGELOG.md");
     const firstRelease = changelog.match(/^## \[([^\]]+)\]/m);
 
-    expect(packageJson.version).toBe("1.2.0");
+    expect(packageJson.version).toBe("1.2.1");
     expect(versionSource).toContain(`SDK_VERSION = "${packageJson.version}"`);
     expect(firstRelease?.[1]).toBe(packageJson.version);
   });
@@ -28,6 +28,7 @@ describe("release readiness", () => {
     expect(workflow).toContain("npm audit --audit-level=low");
     expect(workflow).toContain("npm run smoke:package");
     expect(smokeScript).toMatch(/npm run build[\s\S]*npm pack/);
+    expect(smokeScript).toMatch(/npm install[\s\S]*--package-root/);
   });
 
   it("does not persist checkout credentials in repository workflows", () => {

--- a/tests/resources/streaming.test.ts
+++ b/tests/resources/streaming.test.ts
@@ -186,7 +186,10 @@ describe("StreamingResource", () => {
       ws.serverSend({ identifier: "{}", type: "reject_subscription" });
 
       expect(onError).toHaveBeenCalledOnce();
-      expect((onError.mock.calls[0][0] as Error).message).toMatch(/Professional plan/);
+      const message = (onError.mock.calls[0][0] as Error).message;
+      expect(message).toContain("API key");
+      expect(message).toContain("streaming entitlement");
+      expect(message).toContain("https://www.oilpriceapi.com/pricing");
       handle.close();
     });
   });

--- a/tests/storefront-claims.test.ts
+++ b/tests/storefront-claims.test.ts
@@ -1,9 +1,54 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { validateStorefront } from "../scripts/validate-storefront-claims.mjs";
+import {
+  discoverStorefrontSurfaces,
+  validatePackage,
+  validateStorefront,
+} from "../scripts/validate-storefront-claims.mjs";
+
+const scratch: string[] = [];
+
+afterEach(() => {
+  for (const path of scratch.splice(0)) {
+    rmSync(path, { force: true, recursive: true });
+  }
+});
 
 describe("public storefront claims", () => {
   it("match the reviewed product-facts contract", () => {
     expect(validateStorefront()).toEqual([]);
+  });
+
+  it("discovers generated docs and nested package source", () => {
+    const surfaces = discoverStorefrontSurfaces().map((path) =>
+      relative(process.cwd(), path),
+    );
+
+    expect(surfaces).toContain("docs/index.html");
+    expect(surfaces).toContain("src/index.ts");
+    expect(surfaces).toContain("src/resources/streaming.ts");
+  });
+
+  it("rejects a stale claim introduced only in the packed artifact", () => {
+    const root = mkdtempSync(join(tmpdir(), "oilpriceapi-package-claims-"));
+    scratch.push(root);
+    mkdirSync(join(root, "dist", "resources"), { recursive: true });
+    writeFileSync(
+      join(root, "README.md"),
+      "https://api.oilpriceapi.com/product-facts.json\n",
+    );
+    writeFileSync(join(root, "package.json"), JSON.stringify({ version: "9.9.9" }));
+    writeFileSync(join(root, "dist", "version.js"), 'export const SDK_VERSION = "9.9.9";\n');
+    writeFileSync(
+      join(root, "dist", "resources", "future.d.ts"),
+      "/** Guaranteed 99.9% uptime. */\n",
+    );
+
+    expect(validatePackage(root)).toContainEqual(
+      expect.stringContaining("dist/resources/future.d.ts"),
+    );
   });
 });


### PR DESCRIPTION
## Problem

The storefront guard checked only `README.md` and `package.json`. GitHub Pages and generated npm declarations therefore bypassed it, and the published package still carried fixed plan-price, quota-exemption, cadence, cost-comparison, and generic real-time claims. This is the Node portion of OilpriceAPI/oilpriceapi-api#5644.

## Red / green

Red before implementation:

- recursive-discovery and exact-package regressions: **2 failed / 3**
- after discovery was wired, the current tree exposed **17** blocked customer-visible claims across generated docs and package source
- the existing streaming rejection test then failed on the corrected recovery copy

Green at `0611de6`:

- Vitest: **468 passed, 1 skipped**
- strict ESLint and TypeScript: green
- npm audit: **0 vulnerabilities**
- authored/generated claim scan: **36 surfaces**
- snippet fixtures: **6/6** plus manifest tests **4/4**
- exact packed `oilpriceapi@1.2.1` install: claim scan, ESM production demo, and CommonJS production demo green
- `git diff --check`: clean

## Change

- recursively scan `docs/` and `src/` alongside registry storefront metadata
- scan the exact installed tarball after `npm pack`, including generated JS and declarations
- replace mutable service promises with API-provided source/limit metadata, current pricing links, and entitlement-aware recovery
- correct the Pages npm link to the actual `oilpriceapi` package
- bump the patch candidate to `1.2.1` so npm consumers receive the corrected declarations

No API, entitlement, credential, email, or customer mutation is included.