### PR TITLE
Ship generic futures routes and permit-to-production flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,42 +5,58 @@ on:
     types: [published]
 
 jobs:
-  publish:
-    name: Publish
+  verify:
+    name: Verify release candidate
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
-      contents: write
-      id-token: write
+      contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Upgrade npm (OIDC trusted publishing needs npm >= 11.5.1)
-        run: npm install -g npm@latest
+      - name: Install pinned npm for trusted publishing
+        run: npm install --global npm@11.12.1
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify release tag matches package version
+      - name: Verify release tag matches package version and protected main
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          set -euo pipefail
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
           if [ "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]; then
             echo "::error::Release tag $RELEASE_TAG does not match package version $PACKAGE_VERSION"
             exit 1
           fi
 
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          RELEASE_COMMIT="$(git rev-parse "$RELEASE_TAG^{commit}")"
+          if [ "$RELEASE_COMMIT" != "$(git rev-parse HEAD)" ]; then
+            echo "::error::Checked-out commit does not match $RELEASE_TAG"
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main; then
+            echo "::error::$RELEASE_TAG is not reachable from protected main"
+            exit 1
+          fi
+
       - name: Audit dependencies
         run: npm audit --audit-level=low
+
+      - name: Check for committed credentials
+        run: npm run check:secrets
 
       - name: TypeScript build check
         run: npx tsc --noEmit
@@ -57,19 +73,127 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Validate executable snippets
+        run: npm run snippets:check
+
       - name: Install and exercise the exact package tarball
         run: npm run smoke:package
 
       - name: Build signed snippet manifest
-        run: npm run snippets:build -- --source-commit "$GITHUB_SHA"
+        run: npm run snippets:build -- --source-commit "$(git rev-parse HEAD)"
 
-      - name: Attach snippet manifest to release
+      - name: Pack the verified package and publisher
+        run: |
+          set -euo pipefail
+          ARTIFACT_DIR="$RUNNER_TEMP/release-artifact"
+          mkdir -p "$ARTIFACT_DIR/snippets"
+
+          npm pack --ignore-scripts --json --pack-destination "$ARTIFACT_DIR" \
+            > "$RUNNER_TEMP/npm-pack.json"
+          jq -e '.[0] | {filename, integrity, shasum}' \
+            "$RUNNER_TEMP/npm-pack.json" > "$ARTIFACT_DIR/pack-metadata.json"
+          cp artifacts/snippets/* "$ARTIFACT_DIR/snippets/"
+
+          NPM_ROOT="$(npm root --global)"
+          tar -czf "$ARTIFACT_DIR/npm-cli-11.12.1.tgz" -C "$NPM_ROOT" npm
+          (
+            cd "$ARTIFACT_DIR"
+            find . -type f ! -name artifact.sha256 -print0 \
+              | sort -z \
+              | xargs -0 sha256sum > artifact.sha256
+          )
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: verified-npm-package
+          path: ${{ runner.temp }}/release-artifact/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish verified package to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: verify
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: verified-npm-package
+          path: ${{ runner.temp }}/release-artifact
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      # The only package-manager code used with OIDC is the archive prepared by
+      # the unprivileged verify job and checked before extraction.
+      - name: Publish the exact verified tarball
+        working-directory: ${{ runner.temp }}/release-artifact
+        run: |
+          set -euo pipefail
+          sha256sum -c artifact.sha256
+
+          mkdir "$RUNNER_TEMP/npm-cli"
+          tar -xzf npm-cli-11.12.1.tgz -C "$RUNNER_TEMP/npm-cli"
+          NPM=(node "$RUNNER_TEMP/npm-cli/npm/bin/npm-cli.js")
+
+          PACKAGE_FILE="$(jq -er '.filename' pack-metadata.json)"
+          EXPECTED_INTEGRITY="$(jq -er '.integrity' pack-metadata.json)"
+          NAME="$(tar -xOf "$PACKAGE_FILE" package/package.json | jq -er '.name')"
+          VERSION="$(tar -xOf "$PACKAGE_FILE" package/package.json | jq -er '.version')"
+          EXISTING_INTEGRITY="$(timeout 30s "${NPM[@]}" view "$NAME@$VERSION" dist.integrity --json 2>/dev/null | jq -r '. // empty' || true)"
+
+          if [ -n "$EXISTING_INTEGRITY" ]; then
+            if [ "$EXISTING_INTEGRITY" != "$EXPECTED_INTEGRITY" ]; then
+              echo "::error::npm $NAME@$VERSION exists with unexpected integrity"
+              exit 1
+            fi
+            echo "npm $NAME@$VERSION already matches the verified tarball; continuing recovery."
+          else
+            timeout 10m "${NPM[@]}" publish "$PACKAGE_FILE" \
+              --ignore-scripts --provenance --access public
+          fi
+
+          for attempt in $(seq 1 12); do
+            PUBLIC_INTEGRITY="$(timeout 30s "${NPM[@]}" view "$NAME@$VERSION" dist.integrity --json 2>/dev/null | jq -r '. // empty' || true)"
+            PUBLIC_LATEST="$(timeout 30s "${NPM[@]}" view "$NAME" dist-tags.latest --json 2>/dev/null | jq -r '. // empty' || true)"
+            if [ "$PUBLIC_INTEGRITY" = "$EXPECTED_INTEGRITY" ] && [ "$PUBLIC_LATEST" = "$VERSION" ]; then
+              echo "Verified npm $NAME@$VERSION integrity and latest tag."
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "::error::npm public readback did not converge to the verified release"
+          exit 1
+
+  release_assets:
+    name: Attach verified release assets
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: publish
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: verified-npm-package
+          path: ${{ runner.temp }}/release-artifact
+
+      - name: Attach checksummed snippet manifest to release
+        working-directory: ${{ runner.temp }}/release-artifact
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" artifacts/snippets/* --clobber
-
-      # Authentication via OIDC Trusted Publishing (configured on npmjs.com).
-      # No NODE_AUTH_TOKEN needed; OIDC also satisfies the package 2FA requirement
-      # and produces provenance automatically.
-      - name: Publish to npm
-        run: npm publish --provenance --access public
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          sha256sum -c artifact.sha256
+          gh release upload "$RELEASE_TAG" snippets/* --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-08-11
+
+### Added
+
+- Document a coverage-gated permit-to-production flow using live permit search
+  results and per-well monthly production history.
+- Add well-permit, drilling-data, and oil-well-production discovery keywords.
+
+### Fixed
+
+- Route futures contract codes and named helpers through instrument-generic
+  Brent, WTI, Gasoil, and EU-carbon paths while retaining explicit legacy
+  slugs as backward-compatible inputs.
+- Unwrap the production `{ well_permits, meta }` search envelope and expose its
+  rich typed permit records so a returned API number can feed well history.
+
 ## [1.2.1] - 2026-08-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Route futures contract codes and named helpers through instrument-generic
   Brent, WTI, Gasoil, and EU-carbon paths while retaining explicit legacy
   slugs as backward-compatible inputs.
-- Unwrap the production `{ well_permits, meta }` search envelope and expose its
-  rich typed permit records so a returned API number can feed well history.
+- Unwrap the production `{ well_permits, meta }` search envelope through the new
+  `searchLatest()` method while preserving the existing `search()` return type.
 
 ## [1.2.1] - 2026-08-11
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,35 @@ The reviewed standalone form is
 type-checks and executes it against production-shaped fixtures, then publishes
 its exact code and checksum in the release snippet manifest.
 
+## Permit To Production
+
+Well-level production coverage is narrower than permit coverage. Check the live
+coverage response before following a permit into monthly production history:
+
+```typescript
+const summary = await client.wellProduction.summary();
+if (!summary.coverage) {
+  throw new Error("MALFORMED_RESPONSE: well-production coverage is missing");
+}
+const coveredStates = new Set(summary.coverage.well_level_states_with_data ?? []);
+const permits = await client.ei.wellPermits.search({
+  states: "TX",
+  well_name: "Eagle",
+});
+
+for (const permit of permits) {
+  if (!coveredStates.has(permit.state_code) || !/^\d{14}$/.test(permit.api_number ?? "")) {
+    continue;
+  }
+
+  const production = await client.wellProduction.wellDetail(permit.api_number!);
+  console.log(permit.well.name, production.data);
+}
+```
+
+An empty search or history is a valid data state. Do not infer nationwide
+well-level coverage from the presence of permit data or an SDK method.
+
 ## CommonJS
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ if (!summary.coverage) {
   throw new Error("MALFORMED_RESPONSE: well-production coverage is missing");
 }
 const coveredStates = new Set(summary.coverage.well_level_states_with_data ?? []);
-const permits = await client.ei.wellPermits.search({
+const permits = await client.ei.wellPermits.searchLatest({
   states: "TX",
   well_name: "Eagle",
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.21.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Official Node.js SDK for source-timestamped OilPriceAPI energy data",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -51,7 +51,10 @@
     "energy",
     "alerts",
     "webhook",
-    "notifications"
+    "notifications",
+    "well-permits",
+    "drilling-data",
+    "oil-well-production"
   ],
   "author": "OilPriceAPI <support@oilpriceapi.com>",
   "license": "MIT",

--- a/src/resources/ei/well-permits.ts
+++ b/src/resources/ei/well-permits.ts
@@ -221,7 +221,7 @@ export interface WellPermitSearchQuery {
  * states.forEach(s => console.log(`${s.state}: ${s.permit_count} permits`));
  *
  * // Search permits
- * const results = await client.ei.wellPermits.search({
+ * const results = await client.ei.wellPermits.searchLatest({
  *   states: 'TX,NM',
  *   well_name: 'Eagle'
  * });
@@ -320,12 +320,42 @@ export class EIWellPermitsResource {
   }
 
   /**
-   * Search well permits
+   * Search well permits using the legacy flat record contract.
    *
    * @param query - Search query parameters
    * @returns Array of matching well permit records
    */
-  async search(query: WellPermitSearchQuery): Promise<LatestWellPermit[]> {
+  async search(query: WellPermitSearchQuery): Promise<WellPermitRecord[]> {
+    const params = this.searchParams(query);
+    const response = await this.client["request"]<
+      WellPermitRecord[] | { data: WellPermitRecord[] }
+    >("/v1/ei/well-permits/search", params);
+
+    return Array.isArray(response) ? response : response.data;
+  }
+
+  /**
+   * Search the current rich well-permit dataset.
+   *
+   * This method matches the production response without changing the public
+   * return type of {@link search} in a patch release.
+   *
+   * @param query - Search query parameters
+   * @returns Array of rich well-permit records
+   */
+  async searchLatest(query: WellPermitSearchQuery): Promise<LatestWellPermit[]> {
+    const params = this.searchParams(query);
+    const response = await this.client["request"]<
+      | LatestWellPermit[]
+      | { data: LatestWellPermit[] }
+      | { well_permits: LatestWellPermit[]; meta?: Record<string, unknown> }
+    >("/v1/ei/well-permits/search", params);
+
+    if (Array.isArray(response)) return response;
+    return "well_permits" in response ? response.well_permits : response.data;
+  }
+
+  private searchParams(query: WellPermitSearchQuery): Record<string, string> {
     const params: Record<string, string> = {};
 
     if (query.states) params.states = query.states;
@@ -340,13 +370,6 @@ export class EIWellPermitsResource {
     if (query.start_date) params.start_date = query.start_date;
     if (query.end_date) params.end_date = query.end_date;
 
-    const response = await this.client["request"]<
-      | LatestWellPermit[]
-      | { data: LatestWellPermit[] }
-      | { well_permits: LatestWellPermit[]; meta?: Record<string, unknown> }
-    >("/v1/ei/well-permits/search", params);
-
-    if (Array.isArray(response)) return response;
-    return "well_permits" in response ? response.well_permits : response.data;
+    return params;
   }
 }

--- a/src/resources/ei/well-permits.ts
+++ b/src/resources/ei/well-permits.ts
@@ -325,7 +325,7 @@ export class EIWellPermitsResource {
    * @param query - Search query parameters
    * @returns Array of matching well permit records
    */
-  async search(query: WellPermitSearchQuery): Promise<WellPermitRecord[]> {
+  async search(query: WellPermitSearchQuery): Promise<LatestWellPermit[]> {
     const params: Record<string, string> = {};
 
     if (query.states) params.states = query.states;
@@ -341,9 +341,12 @@ export class EIWellPermitsResource {
     if (query.end_date) params.end_date = query.end_date;
 
     const response = await this.client["request"]<
-      WellPermitRecord[] | { data: WellPermitRecord[] }
+      | LatestWellPermit[]
+      | { data: LatestWellPermit[] }
+      | { well_permits: LatestWellPermit[]; meta?: Record<string, unknown> }
     >("/v1/ei/well-permits/search", params);
 
-    return Array.isArray(response) ? response : response.data;
+    if (Array.isArray(response)) return response;
+    return "well_permits" in response ? response.well_permits : response.data;
   }
 }

--- a/src/resources/futures.ts
+++ b/src/resources/futures.ts
@@ -264,7 +264,7 @@ export interface FuturesSpreadHistoryPoint {
  * Spread-history data for a contract family.
  */
 export interface FuturesSpreadHistory {
-  /** Contract family slug (e.g., "ice-brent") */
+  /** Contract family slug (e.g., "brent") */
   family: string;
   /** Array of historical spread points */
   history: FuturesSpreadHistoryPoint[];
@@ -279,6 +279,10 @@ export interface FuturesSpreadHistory {
  * `/ohlc`, `/intraday`, `/spreads`, `/curve`, and `/spread-history`.
  */
 export type FuturesContractFamilySlug =
+  | "brent"
+  | "gasoil"
+  | "wti"
+  | "eu-carbon"
   | "ice-brent"
   | "ice-gasoil"
   | "ice-wti"
@@ -300,7 +304,7 @@ export type FuturesContractFamilySlug =
  * import { FUTURES_CONTRACTS } from 'oilpriceapi';
  *
  * const brent = await client.futures.latest(FUTURES_CONTRACTS.BRENT); // "BZ"
- * const gasoil = await client.futures.family('ice-gasoil').latest();
+ * const gasoil = await client.futures.family('gasoil').latest();
  * ```
  */
 export const FUTURES_CONTRACTS = {
@@ -329,20 +333,20 @@ export const FUTURES_CONTRACTS = {
  * path segment used by the typed family helpers.
  */
 export const FUTURES_FAMILY_SLUGS: Record<string, FuturesContractFamilySlug> = {
-  [FUTURES_CONTRACTS.BRENT]: "ice-brent", // BZ
-  [FUTURES_CONTRACTS.WTI]: "ice-wti", // CL
-  [FUTURES_CONTRACTS.GASOIL]: "ice-gasoil", // G
-  QS: "ice-gasoil", // ICE Gasoil also trades under the QS ticker prefix
+  [FUTURES_CONTRACTS.BRENT]: "brent", // BZ
+  [FUTURES_CONTRACTS.WTI]: "wti", // CL
+  [FUTURES_CONTRACTS.GASOIL]: "gasoil", // G
+  QS: "gasoil", // ICE Gasoil also trades under the QS ticker prefix
   [FUTURES_CONTRACTS.NATURAL_GAS]: "natural-gas", // NG
   [FUTURES_CONTRACTS.TTF_GAS]: "ttf-gas", // TTF
   [FUTURES_CONTRACTS.LNG_JKM]: "lng-jkm", // JKM
-  [FUTURES_CONTRACTS.EUA_CARBON]: "eua-carbon", // EUA
+  [FUTURES_CONTRACTS.EUA_CARBON]: "eu-carbon", // EUA
   [FUTURES_CONTRACTS.UK_CARBON]: "uk-carbon", // UKA
 };
 
 /**
  * Resolve a futures contract code (e.g. `"BZ"`, `"QS"`) or an already-valid
- * family slug (e.g. `"ice-brent"`) to its `/v1/futures/{slug}` path segment.
+ * family slug (e.g. `"brent"`) to its `/v1/futures/{slug}` path segment.
  *
  * Matching is case-insensitive for codes. Returns `null` if the input maps to
  * neither a known code nor a known family slug.
@@ -354,7 +358,13 @@ export function resolveFuturesFamilySlug(codeOrSlug: string): FuturesContractFam
   if (byCode) return byCode;
   // Already a valid family slug?
   const lower = trimmed.toLowerCase();
-  const isSlug = Object.values(FUTURES_FAMILY_SLUGS).includes(lower as FuturesContractFamilySlug);
+  const isSlug = new Set<FuturesContractFamilySlug>([
+    ...Object.values(FUTURES_FAMILY_SLUGS),
+    "ice-brent",
+    "ice-wti",
+    "ice-gasoil",
+    "eua-carbon",
+  ]).has(lower as FuturesContractFamilySlug);
   return isSlug ? (lower as FuturesContractFamilySlug) : null;
 }
 
@@ -470,7 +480,7 @@ export class FuturesContractFamily {
  *
  * const client = new OilPriceAPI({ apiKey: 'your_key' });
  *
- * // Get the latest curve by contract code (resolves to GET /v1/futures/ice-wti)
+ * // Get the latest curve by contract code (resolves to GET /v1/futures/wti)
  * const latest = await client.futures.latest('CL');
  * console.log(`${latest.contract}: $${latest.price}`);
  *
@@ -489,15 +499,15 @@ export class FuturesResource {
    * Get the latest curve/quote for a futures contract family.
    *
    * Accepts an ergonomic contract code (e.g. `"BZ"`, `"CL"`, `"QS"`) or a
-   * family slug (e.g. `"ice-brent"`). The code is resolved to its family slug
+   * family slug (e.g. `"brent"`). The code is resolved to its family slug
    * and the request is sent to `GET /v1/futures/{slug}` — the bare slug path,
    * with NO `/latest` suffix (the suffixed path 404s).
    *
    * Supported codes: BZ (Brent), CL (WTI), G/QS (Gasoil), NG (Natural Gas),
-   * TTF, JKM, EUA, UKA. Slugs: ice-brent, ice-wti, ice-gasoil, natural-gas,
-   * ttf-gas, lng-jkm, eua-carbon, uk-carbon.
+   * TTF, JKM, EUA, UKA. Canonical slugs: brent, wti, gasoil, natural-gas,
+   * ttf-gas, lng-jkm, eu-carbon, uk-carbon.
    *
-   * @param contract - Contract code (e.g. "BZ") or family slug (e.g. "ice-brent").
+   * @param contract - Contract code (e.g. "BZ") or family slug (e.g. "brent").
    * @returns Latest futures price/curve data
    *
    * @throws {ValidationError} If the code/slug is empty or unrecognized.
@@ -507,7 +517,7 @@ export class FuturesResource {
    * ```typescript
    * import { FUTURES_CONTRACTS } from 'oilpriceapi';
    * const price = await client.futures.latest(FUTURES_CONTRACTS.BRENT); // "BZ"
-   * const wti = await client.futures.latest('ice-wti');
+   * const wti = await client.futures.latest('wti');
    * ```
    */
   async latest(contract: string): Promise<FuturesPrice> {
@@ -520,8 +530,7 @@ export class FuturesResource {
       throw new ValidationError(
         `Unknown futures contract "${contract}". Use a contract code ` +
           `(BZ, CL, G, QS, NG, TTF, JKM, EUA, UKA) or a family slug ` +
-          `(ice-brent, ice-wti, ice-gasoil, natural-gas, ttf-gas, lng-jkm, ` +
-          `eua-carbon, uk-carbon).`,
+          `(brent, wti, gasoil, natural-gas, ttf-gas, lng-jkm, eu-carbon, uk-carbon).`,
       );
     }
 
@@ -724,12 +733,12 @@ export class FuturesResource {
    * family endpoints (`/latest`, `/historical`, `/ohlc`, `/intraday`,
    * `/spreads`, `/curve`, `/spread-history`) without remembering the URL slug.
    *
-   * @param slug - Contract family slug (e.g., `"ice-brent"`, `"ice-gasoil"`).
+   * @param slug - Contract family slug (e.g., `"brent"`, `"gasoil"`).
    * @returns A {@link FuturesContractFamily} bound to the slug.
    *
    * @example
    * ```typescript
-   * const brent = client.futures.family('ice-brent');
+   * const brent = client.futures.family('brent');
    * const latest = await brent.latest();
    * const curve = await brent.curve();
    * ```
@@ -743,17 +752,17 @@ export class FuturesResource {
 
   /** ICE Brent crude futures family helper (issue #1). */
   brent(): FuturesContractFamily {
-    return this.family("ice-brent");
+    return this.family("brent");
   }
 
   /** ICE WTI crude futures family helper. */
   wti(): FuturesContractFamily {
-    return this.family("ice-wti");
+    return this.family("wti");
   }
 
   /** ICE Gasoil futures family helper (issue #1). */
   gasoil(): FuturesContractFamily {
-    return this.family("ice-gasoil");
+    return this.family("gasoil");
   }
 
   /** Henry Hub natural gas futures family helper. */
@@ -773,7 +782,7 @@ export class FuturesResource {
 
   /** EU carbon allowance (EUA) futures family helper. */
   euaCarbon(): FuturesContractFamily {
-    return this.family("eua-carbon");
+    return this.family("eu-carbon");
   }
 
   /** UK carbon allowance (UKA) futures family helper. */

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,7 +7,7 @@
  * - X-Client-Version header
  * - Package.json (should match)
  */
-export const SDK_VERSION = "1.2.1";
+export const SDK_VERSION = "1.2.2";
 
 /**
  * SDK identifier used in User-Agent and X-Api-Client headers

--- a/tests/release-readiness.test.ts
+++ b/tests/release-readiness.test.ts
@@ -65,7 +65,7 @@ describe("release readiness", () => {
     const packageJson = JSON.parse(read("package.json")) as { keywords: string[] };
 
     expect(readme).toContain("coverage.well_level_states_with_data");
-    expect(readme).toContain("client.ei.wellPermits.search");
+    expect(readme).toContain("client.ei.wellPermits.searchLatest");
     expect(readme).toContain("client.wellProduction.wellDetail");
     expect(packageJson.keywords).toEqual(
       expect.arrayContaining(["well-permits", "drilling-data", "oil-well-production"]),

--- a/tests/release-readiness.test.ts
+++ b/tests/release-readiness.test.ts
@@ -10,7 +10,7 @@ describe("release readiness", () => {
     const changelog = read("CHANGELOG.md");
     const firstRelease = changelog.match(/^## \[([^\]]+)\]/m);
 
-    expect(packageJson.version).toBe("1.2.1");
+    expect(packageJson.version).toBe("1.2.2");
     expect(versionSource).toContain(`SDK_VERSION = "${packageJson.version}"`);
     expect(firstRelease?.[1]).toBe(packageJson.version);
   });
@@ -31,6 +31,25 @@ describe("release readiness", () => {
     expect(smokeScript).toMatch(/npm install[\s\S]*--package-root/);
   });
 
+  it("keeps dependency execution outside the checksummed OIDC publisher", () => {
+    const workflow = read(".github/workflows/publish.yml");
+    const publishJob = workflow
+      .split(/\n(?=  [a-z][a-z0-9_-]*:\n)/)
+      .find((section) => section.startsWith("  publish:\n"));
+    const actions = workflow.match(/uses:\s+actions\/[^@\s]+@([^\s#]+)/g) ?? [];
+
+    expect(workflow).toContain("Verify release tag matches package version and protected main");
+    expect(workflow).toContain("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a");
+    expect(workflow).toContain("actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c");
+    expect(publishJob).toContain("id-token: write");
+    expect(publishJob).toContain("sha256sum -c artifact.sha256");
+    expect(publishJob).not.toMatch(/npm (?:ci|install)/);
+    expect(publishJob).not.toContain("npx ");
+    expect(publishJob).not.toContain("actions/checkout@");
+    expect(actions).not.toHaveLength(0);
+    for (const action of actions) expect(action).toMatch(/@[0-9a-f]{40}$/);
+  });
+
   it("does not persist checkout credentials in repository workflows", () => {
     for (const name of readdirSync(".github/workflows").filter((file) => file.endsWith(".yml"))) {
       const workflow = read(`.github/workflows/${name}`);
@@ -39,5 +58,17 @@ describe("release readiness", () => {
 
       expect(hardenedCount, name).toBe(checkoutCount);
     }
+  });
+
+  it("documents a coverage-gated permit-to-production customer path", () => {
+    const readme = read("README.md");
+    const packageJson = JSON.parse(read("package.json")) as { keywords: string[] };
+
+    expect(readme).toContain("coverage.well_level_states_with_data");
+    expect(readme).toContain("client.ei.wellPermits.search");
+    expect(readme).toContain("client.wellProduction.wellDetail");
+    expect(packageJson.keywords).toEqual(
+      expect.arrayContaining(["well-permits", "drilling-data", "oil-well-production"]),
+    );
   });
 });

--- a/tests/resources/ei.test.ts
+++ b/tests/resources/ei.test.ts
@@ -248,7 +248,25 @@ describe("EnergyIntelligenceResource (ei.*)", () => {
       expect(calls).toContain("/v1/ei/well-permits/by-formation");
     });
 
-    it("search() passes query params", async () => {
+    it("search() preserves the legacy response contract", async () => {
+      const permit = {
+        id: "legacy-1",
+        state: "TX",
+        issue_date: "2024-01-15",
+        timestamp: "2024-01-16T00:00:00Z",
+      };
+      const s = spy({ data: [permit] });
+      const results = await client.ei.wellPermits.search({ states: "TX" });
+
+      expect(s).toHaveBeenCalledWith("/v1/ei/well-permits/search", { states: "TX" });
+      expect(results).toEqual([permit]);
+    });
+
+    it.each([
+      ["raw array", (permit: object) => [permit]],
+      ["data envelope", (permit: object) => ({ data: [permit] })],
+      ["production envelope", (permit: object) => ({ well_permits: [permit], meta: { count: 1 } })],
+    ])("searchLatest() unwraps the %s and passes query params", async (_shape, response) => {
       const permit = {
         api_number: "42329000000001",
         state_code: "TX",
@@ -263,8 +281,8 @@ describe("EnergyIntelligenceResource (ei.*)", () => {
         target: { formation: null, formation_normalized: null, total_depth_proposed: null },
         provenance: { source: "texas_rrc", fetched_at: "2024-01-16T00:00:00Z" },
       };
-      const s = spy({ well_permits: [permit], meta: { count: 1 } });
-      const results = await client.ei.wellPermits.search({
+      const s = spy(response(permit));
+      const results = await client.ei.wellPermits.searchLatest({
         states: "TX,NM",
         county: "Midland",
         start_date: "2024-01-01",

--- a/tests/resources/ei.test.ts
+++ b/tests/resources/ei.test.ts
@@ -249,8 +249,22 @@ describe("EnergyIntelligenceResource (ei.*)", () => {
     });
 
     it("search() passes query params", async () => {
-      const s = spy([]);
-      await client.ei.wellPermits.search({
+      const permit = {
+        api_number: "42329000000001",
+        state_code: "TX",
+        county: "Midland",
+        permit_number: "P-1",
+        permit_type: "new_drill",
+        permit_status: "approved",
+        permit_date: "2024-01-15",
+        operator: { name: "Operator", name_normalized: "OPERATOR", number: null },
+        well: { name: "Eagle 1", number: "1", type: "oil" },
+        location: { latitude: null, longitude: null },
+        target: { formation: null, formation_normalized: null, total_depth_proposed: null },
+        provenance: { source: "texas_rrc", fetched_at: "2024-01-16T00:00:00Z" },
+      };
+      const s = spy({ well_permits: [permit], meta: { count: 1 } });
+      const results = await client.ei.wellPermits.search({
         states: "TX,NM",
         county: "Midland",
         start_date: "2024-01-01",
@@ -263,6 +277,7 @@ describe("EnergyIntelligenceResource (ei.*)", () => {
         start_date: "2024-01-01",
         end_date: "2024-12-31",
       });
+      expect(results).toEqual([permit]);
     });
 
     it("get() validates id", async () => {

--- a/tests/resources/futures-family.test.ts
+++ b/tests/resources/futures-family.test.ts
@@ -29,10 +29,10 @@ describe("Futures contract families (issue #1)", () => {
     });
 
     it("maps codes to family slugs", () => {
-      expect(FUTURES_FAMILY_SLUGS[FUTURES_CONTRACTS.BRENT]).toBe("ice-brent");
-      expect(FUTURES_FAMILY_SLUGS[FUTURES_CONTRACTS.GASOIL]).toBe("ice-gasoil");
+      expect(FUTURES_FAMILY_SLUGS[FUTURES_CONTRACTS.BRENT]).toBe("brent");
+      expect(FUTURES_FAMILY_SLUGS[FUTURES_CONTRACTS.GASOIL]).toBe("gasoil");
       expect(FUTURES_FAMILY_SLUGS[FUTURES_CONTRACTS.TTF_GAS]).toBe("ttf-gas");
-      expect(FUTURES_FAMILY_SLUGS[FUTURES_CONTRACTS.EUA_CARBON]).toBe("eua-carbon");
+      expect(FUTURES_FAMILY_SLUGS[FUTURES_CONTRACTS.EUA_CARBON]).toBe("eu-carbon");
     });
   });
 
@@ -52,13 +52,13 @@ describe("Futures contract families (issue #1)", () => {
 
   describe("named family helpers map to correct slugs", () => {
     it.each([
-      ["brent", "ice-brent"],
-      ["wti", "ice-wti"],
-      ["gasoil", "ice-gasoil"],
+      ["brent", "brent"],
+      ["wti", "wti"],
+      ["gasoil", "gasoil"],
       ["naturalGas", "natural-gas"],
       ["ttfGas", "ttf-gas"],
       ["lngJkm", "lng-jkm"],
-      ["euaCarbon", "eua-carbon"],
+      ["euaCarbon", "eu-carbon"],
       ["ukCarbon", "uk-carbon"],
     ])("futures.%s() -> %s", (method, slug) => {
       const fam = (client.futures as any)[method]();
@@ -75,7 +75,7 @@ describe("Futures contract families (issue #1)", () => {
       await client.futures.gasoil().latest();
 
       // The correct latest endpoint is the bare slug; `/latest` 404s.
-      expect(spy).toHaveBeenCalledWith("/v1/futures/ice-gasoil", {});
+      expect(spy).toHaveBeenCalledWith("/v1/futures/gasoil", {});
     });
 
     it("historical() passes date params", async () => {
@@ -87,7 +87,7 @@ describe("Futures contract families (issue #1)", () => {
       });
 
       // Controller reads from/to, not start_date/end_date.
-      expect(spy).toHaveBeenCalledWith("/v1/futures/ice-brent/historical", {
+      expect(spy).toHaveBeenCalledWith("/v1/futures/brent/historical", {
         from: "2024-01-01",
         to: "2024-01-31",
       });
@@ -107,7 +107,7 @@ describe("Futures contract families (issue #1)", () => {
 
       await client.futures.wti().ohlc({ days: 30, interval: "1d" });
 
-      expect(spy).toHaveBeenCalledWith("/v1/futures/ice-wti/ohlc", {
+      expect(spy).toHaveBeenCalledWith("/v1/futures/wti/ohlc", {
         days: "30",
         interval: "1d",
       });
@@ -138,28 +138,28 @@ describe("Futures contract families (issue #1)", () => {
     it("spreadHistory() hits /spread-history", async () => {
       const spy = vi.spyOn(client as any, "request").mockResolvedValue({});
       await client.futures.euaCarbon().spreadHistory();
-      expect(spy).toHaveBeenCalledWith("/v1/futures/eua-carbon/spread-history", {});
+      expect(spy).toHaveBeenCalledWith("/v1/futures/eu-carbon/spread-history", {});
     });
   });
 
   describe("resolveFuturesFamilySlug()", () => {
     it.each([
-      ["BZ", "ice-brent"],
-      ["CL", "ice-wti"],
-      ["G", "ice-gasoil"],
-      ["QS", "ice-gasoil"], // Gasoil also trades under the QS ticker prefix
+      ["BZ", "brent"],
+      ["CL", "wti"],
+      ["G", "gasoil"],
+      ["QS", "gasoil"], // Gasoil also trades under the QS ticker prefix
       ["NG", "natural-gas"],
       ["TTF", "ttf-gas"],
       ["JKM", "lng-jkm"],
-      ["EUA", "eua-carbon"],
+      ["EUA", "eu-carbon"],
       ["UKA", "uk-carbon"],
     ])("resolves code %s -> %s", (code, slug) => {
       expect(resolveFuturesFamilySlug(code)).toBe(slug);
     });
 
     it("resolves codes case-insensitively", () => {
-      expect(resolveFuturesFamilySlug("bz")).toBe("ice-brent");
-      expect(resolveFuturesFamilySlug("qs")).toBe("ice-gasoil");
+      expect(resolveFuturesFamilySlug("bz")).toBe("brent");
+      expect(resolveFuturesFamilySlug("qs")).toBe("gasoil");
     });
 
     it("passes through already-valid family slugs", () => {
@@ -175,14 +175,14 @@ describe("Futures contract families (issue #1)", () => {
 
   describe("top-level futures.latest(code) maps code -> /v1/futures/{slug}", () => {
     it.each([
-      ["BZ", "ice-brent"],
-      ["CL", "ice-wti"],
-      ["G", "ice-gasoil"],
-      ["QS", "ice-gasoil"],
+      ["BZ", "brent"],
+      ["CL", "wti"],
+      ["G", "gasoil"],
+      ["QS", "gasoil"],
       ["NG", "natural-gas"],
       ["TTF", "ttf-gas"],
       ["JKM", "lng-jkm"],
-      ["EUA", "eua-carbon"],
+      ["EUA", "eu-carbon"],
       ["UKA", "uk-carbon"],
     ])("latest('%s') -> GET /v1/futures/%s (no /latest suffix)", async (code, slug) => {
       const spy = vi

--- a/tests/resources/futures-family.test.ts
+++ b/tests/resources/futures-family.test.ts
@@ -162,9 +162,17 @@ describe("Futures contract families (issue #1)", () => {
       expect(resolveFuturesFamilySlug("qs")).toBe("gasoil");
     });
 
-    it("passes through already-valid family slugs", () => {
-      expect(resolveFuturesFamilySlug("ice-brent")).toBe("ice-brent");
-      expect(resolveFuturesFamilySlug("ICE-BRENT")).toBe("ice-brent");
+    it.each([
+      ["ice-brent", "ice-brent"],
+      ["ICE-BRENT", "ice-brent"],
+      ["ice-wti", "ice-wti"],
+      ["ICE-WTI", "ice-wti"],
+      ["ice-gasoil", "ice-gasoil"],
+      ["ICE-GASOIL", "ice-gasoil"],
+      ["eua-carbon", "eua-carbon"],
+      ["EUA-CARBON", "eua-carbon"],
+    ])("passes through legacy family slug %s", (input, expected) => {
+      expect(resolveFuturesFamilySlug(input)).toBe(expected);
     });
 
     it("returns null for unknown codes/slugs", () => {

--- a/tests/resources/futures.test.ts
+++ b/tests/resources/futures.test.ts
@@ -47,11 +47,11 @@ describe("FuturesResource", () => {
 
       const requestSpy = vi.spyOn(client as any, "request").mockResolvedValue(mockPrice);
 
-      // "CL" resolves to the ice-wti family; latest is the bare slug path
-      // (GET /v1/futures/ice-wti) — there is NO /latest suffix.
+      // "CL" resolves to the venue-neutral WTI family; latest is the bare slug
+      // path (GET /v1/futures/wti) — there is NO /latest suffix.
       const result = await client.futures.latest("CL");
 
-      expect(requestSpy).toHaveBeenCalledWith("/v1/futures/ice-wti", {});
+      expect(requestSpy).toHaveBeenCalledWith("/v1/futures/wti", {});
       expect(result).toEqual(mockPrice);
       // The real latest price is surfaced at front_month.last_price.
       expect(result.front_month?.last_price).toBe(75.5);


### PR DESCRIPTION
## Summary
- route futures codes and named helpers through instrument-generic aliases while preserving explicit legacy slug inputs
- unwrap production-shaped well permit search results and document a coverage-gated permit-to-production flow
- harden trusted publication with protected-main provenance and a checksummed artifact/publisher handoff
- prepare patch release 1.2.2

## Red-green proof
- futures/README contract tests began red: 22 failures across venue paths and the missing coverage path
- production-shaped `{ well_permits, meta }` search regression was added before the unwrapping fix
- release publisher test began red on the single privileged dependency-executing job
- final local: 33 files / 469 passed / 1 skipped; release readiness 5/5

## Verification
- `npm audit --audit-level=low`: 0 vulnerabilities
- `npm run lint`: green, zero warnings
- `npm run storefront:check`: 36 public surfaces
- `npm run check:secrets`: green
- `npm run build`: ESM and CJS green
- `npm run snippets:check`: 6/6 fixtures plus manifest tests
- `npm run smoke:package`: exact packed ESM/CJS keyless production smoke green
- workflow YAML parse and `git diff --check`: green

Closes the Node portions of OilpriceAPI/oilpriceapi-api#4175 and OilpriceAPI/oilpriceapi-api#3941.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Permit to Production guidance for well coverage, permit searches, API validation, and production details.
  * Added well-related package discovery keywords.
  * Introduced canonical futures identifiers for Brent, WTI, Gasoil, and EU carbon while preserving legacy aliases.
  * Improved well permit searches to support structured API responses.

* **Bug Fixes**
  * Improved compatibility with varied permit response formats.

* **Documentation**
  * Added release notes for version 1.2.2 and updated futures examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->