### PR TITLE
Remove stale quota window claim from Node SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2026-08-11
+
+### Fixed
+
+- Remove the stale monthly quota assumption from customer recovery copy and
+  reject fixed daily, weekly, monthly, or yearly quota-window claims even when
+  they do not contain a numeric allowance. Quota recovery now follows the live
+  API response and reviewed product facts.
+
 ## [1.2.3] - 2026-08-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ try {
   } else if (error instanceof TimeoutError) {
     console.error("Retry once, then check https://status.oilpriceapi.com.");
   } else if (isQuotaError(error)) {
-    console.error(`Monthly quota reached; ${error.remediationUrl ?? "review the account"}.`);
+    console.error(
+      `Request quota exhausted; ${error.remediationUrl ?? "follow the API-provided recovery details"}.`,
+    );
   } else if (isEntitlementError(error)) {
     console.error(`This dataset needs the ${error.requiredPlan ?? "required"} plan.`);
   } else if (error instanceof OilPriceAPIError) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oilpriceapi",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oilpriceapi",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.21.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oilpriceapi",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Official Node.js SDK for source-timestamped OilPriceAPI energy data",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/scripts/validate-storefront-claims.mjs
+++ b/scripts/validate-storefront-claims.mjs
@@ -19,6 +19,10 @@ const blocked = [
     /\b(?:1,000|100)\s+requests?(?:\/month|\s+per month|\s+\(lifetime\))/i,
   ],
   ["quota promise", /\bdoes\s+not\s+consume.{0,40}\bquota\b|\bunlimited\s+(?:history|webhooks?|requests?|commodit)/i],
+  [
+    "fixed quota window",
+    /\b(?:daily|weekly|monthly|yearly)\s+(?:(?:api|request)\s+)?quota\b|\b(?:(?:api|request)\s+)?quota\b.{0,40}\b(?:daily|weekly|monthly|yearly)\b/i,
+  ],
   ["free-tier claim", /\bfree\s+tier\b|\bfree\s+api\s+key\b/i],
   ["free endpoint claim", /\b(?:endpoint|resource|api)\s+is\s+free\b|\bincluded\s+in\s+all\s+tiers\b/i],
   ["fixed query allowance", /\b\d[\d,]*\s+(?:station\s+)?queries?\s*(?:\/|per\s+)month\b/i],

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,7 +7,7 @@
  * - X-Client-Version header
  * - Package.json (should match)
  */
-export const SDK_VERSION = "1.2.3";
+export const SDK_VERSION = "1.2.4";
 
 /**
  * SDK identifier used in User-Agent and X-Api-Client headers

--- a/tests/release-readiness.test.ts
+++ b/tests/release-readiness.test.ts
@@ -10,7 +10,7 @@ describe("release readiness", () => {
     const changelog = read("CHANGELOG.md");
     const firstRelease = changelog.match(/^## \[([^\]]+)\]/m);
 
-    expect(packageJson.version).toBe("1.2.3");
+    expect(packageJson.version).toBe("1.2.4");
     expect(versionSource).toContain(`SDK_VERSION = "${packageJson.version}"`);
     expect(firstRelease?.[1]).toBe(packageJson.version);
   });

--- a/tests/storefront-claims.test.ts
+++ b/tests/storefront-claims.test.ts
@@ -51,4 +51,20 @@ describe("public storefront claims", () => {
       expect.stringContaining("dist/resources/future.d.ts"),
     );
   });
+
+  it("rejects a fixed quota window without requiring a numeric allowance", () => {
+    const root = mkdtempSync(join(tmpdir(), "oilpriceapi-package-quota-"));
+    scratch.push(root);
+    mkdirSync(join(root, "dist"), { recursive: true });
+    writeFileSync(
+      join(root, "README.md"),
+      "Monthly quota reached.\nhttps://api.oilpriceapi.com/product-facts.json\n",
+    );
+    writeFileSync(join(root, "package.json"), JSON.stringify({ version: "9.9.9" }));
+    writeFileSync(join(root, "dist", "version.js"), 'export const SDK_VERSION = "9.9.9";\n');
+
+    expect(validatePackage(root)).toContainEqual(
+      expect.stringContaining("fixed quota window"),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- release 1.2.4 to remove the packaged README's stale `Monthly quota reached` recovery assumption
- use account/API-provided recovery details without asserting a fixed entitlement window
- make storefront and exact-package validation reject daily, weekly, monthly, or yearly quota claims even when no numeric allowance is present

## Red / green
- Red: a packed fixture containing `Monthly quota reached` returned no claim failures.
- Green: the new fixed-window regression passes; all 34 files / 493 tests pass (492 passed, 1 skipped); 36 public surfaces and the exact 103-file package are claim-clean; build, lint, audit0, snippets 6/6, and packed ESM/CJS production demo smoke pass.

## Release safety
Publish only from the exact protected-main squash through the recovered typed npm publication workflow. Keep immutable v1.2.2 and v1.2.3 tags/artifacts intact; do not touch the unrelated orphan v1.4.1 tag.
